### PR TITLE
Trim agent connector ids

### DIFF
--- a/src/main/features/agents.ts
+++ b/src/main/features/agents.ts
@@ -883,7 +883,10 @@ export function normalizeAgent(raw: AgentRaw | null | undefined, source: AgentSo
   // share the commander's connector visibility; filtering keeps malformed JSON
   // from injecting weird ids into the detail UI.
   if (Array.isArray(raw.enabled_connectors)) {
-    const filtered = raw.enabled_connectors.filter((v): v is string => typeof v === 'string' && v.length > 0);
+    const filtered = raw.enabled_connectors
+      .filter((v): v is string => typeof v === 'string')
+      .map((v) => v.trim())
+      .filter((v) => v.length > 0 && safeId(v));
     if (filtered.length) agent.enabled_connectors = filtered;
   }
   // interactive — tolerant boolean coerce (LLMs sometimes emit "true"/"false"

--- a/test/main/features/agents.test.ts
+++ b/test/main/features/agents.test.ts
@@ -189,6 +189,15 @@ describe('agents › normalizeAgent', () => {
     expect(norm?.skill_list).toEqual(['ok-one', 'also_ok']);
   });
 
+  it('trims and validates enabled connector ids', async () => {
+    const a = await loadAgents();
+    const norm = a.normalizeAgent({
+      agent_id: 'x', name: 'N',
+      enabled_connectors: [' github ', '', '../evil', 42, 'notion'],
+    } as any, 'custom');
+    expect(norm?.enabled_connectors).toEqual(['github', 'notion']);
+  });
+
   it('normalizes rich profile fields and design aliases', async () => {
     const a = await loadAgents();
     const norm = a.normalizeAgent({


### PR DESCRIPTION
## Summary
- Trim agent enabled connector ids when normalizing agent definitions.
- Drop empty or unsafe connector ids before exposing them in agent metadata.
- Add a regression test for whitespace and invalid connector id inputs.

## Validation
- npm test -- test/main/features/agents.test.ts
- npm run typecheck