### PR TITLE
Validate agent connector ids on update

### DIFF
--- a/src/main/features/agents.ts
+++ b/src/main/features/agents.ts
@@ -1733,7 +1733,10 @@ async function _applyAgentUpdates(
     if (v === null) {
       delete (data as { enabled_connectors?: unknown }).enabled_connectors;
     } else if (Array.isArray(v)) {
-      const ids = v.filter((s): s is string => typeof s === 'string' && s.length > 0);
+      const ids = v
+        .filter((s): s is string => typeof s === 'string')
+        .map((s) => s.trim())
+        .filter((s) => s.length > 0 && safeId(s));
       (data as { enabled_connectors?: string[] }).enabled_connectors = ids;
     }
   }

--- a/test/main/features/agents.test.ts
+++ b/test/main/features/agents.test.ts
@@ -1264,6 +1264,17 @@ describe('agents › updateCustomAgent', () => {
     expect(updated?.skill_list).toEqual(['ok-1', 'ok_2']);
   });
 
+  it('filters invalid enabled connector ids on write', async () => {
+    writeCustomAgent('abc', { name: 'N' });
+    const a = await loadAgents();
+    const updated = await a.updateCustomAgent('abc', {
+      enabled_connectors: [' github ', '../bad', 42 as any, 'notion'],
+    });
+    expect(updated?.enabled_connectors).toEqual(['github', 'notion']);
+    const raw = JSON.parse(fs.readFileSync(path.join(customAgentsDir(), 'abc', 'agent.json'), 'utf8'));
+    expect(raw.enabled_connectors).toEqual(['github', 'notion']);
+  });
+
   it('writes skill_list = [] as explicit zero (kept, not dropped)', async () => {
     writeSkillOnDisk('a');
     writeCustomAgent('abc', { name: 'N', skill_list: ['a'] });


### PR DESCRIPTION
## Summary
- Trim agent enabled connector ids before persisting update payloads.
- Drop empty or unsafe connector ids from custom agent updates.
- Add a regression test covering both the returned agent and raw persisted JSON.

## Validation
- npm test -- test/main/features/agents.test.ts
- npm run typecheck