### PR TITLE
docs: align README positioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Orkas
 
-**Command a team of AI agents from one chat — not a single chatbot.**
+**An open-source, local-first AI workforce for complex work.**
 
-Orkas is an open-source, local-first desktop app: a capable **commander agent** does the work itself and directs specialized sub-agents, all with your own LLM keys. Fully offline-capable. macOS · Windows · Linux.
+Orkas is an open-source, local-first AI workforce. A super-powered **Commander** coordinates specialist agents to complete complex work together. It runs as a desktop app on macOS, Windows, and Linux; your conversations, files, agent configs, and model keys stay local, and model calls go straight to your provider.
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](./LICENSE)
 [![Stars](https://img.shields.io/github/stars/Orkas-AI/Orkas?style=social)](https://github.com/Orkas-AI/Orkas/stargazers)
@@ -15,18 +15,19 @@ Orkas is an open-source, local-first desktop app: a capable **commander agent** 
 
 ![Orkas demo](./resources/app-ui/demo.gif)
 
-> One capable commander agent — with the strengths of a coding agent — does the work itself and directs a team of specialized sub-agents, all by conversation. No flowcharts, no orchestration code. Your conversations, files, and API keys never leave your machine.
+> One super-powered Commander turns your goal into an executable path, does the general work itself, and coordinates specialist agents when the job needs a team. No flowcharts, no orchestration code. Your conversations, files, and API keys never leave your machine.
 
 ---
 
 ## What is Orkas?
 
-- **What it is** — a desktop GUI app where you command a *team* of specialized AI agents through one chat. Not a single chatbot, not a code framework, not a hosted SaaS.
-- **A commander that does, not just delegates** — the lead agent brings coding-agent strengths (precise file edits, careful tool use, engineering discipline, multi-step and long-horizon reasoning) and does the work itself; when a job needs a team, it assembles sub-agents to run in parallel or in series.
-- **Drives the open-source ecosystem** — plug in external CLI coding agents (Claude Code, Codex, OpenCode, Cline) and onboard open-source projects like HyperFrames as local tools — so one commander can deliver code, research, data, video, and slides.
-- **Local-first** — conversations, files, API keys, knowledge bases, and custom agents all stay on your disk. Model calls go straight from your machine to the provider — never through Orkas servers.
+- **Open-source, local-first AI workforce** — a desktop GUI where you direct a coordinated workforce of specialist AI agents through one chat. Not a single chatbot, not a code framework, not a hosted SaaS.
+- **A super-powered Commander** — the Commander understands context, breaks down goals, chooses the right agents, skills, connectors, and tools, and directly handles general analysis, writing, research, file work, and automation when no specialist is a better fit.
+- **Specialist agents that work together** — agents can run in parallel or in sequence, each with focused skills, memory, and task context, so complex work can move across coding, research, data, video, and slides.
+- **Open-source ecosystem, locally orchestrated** — plug in external CLI coding agents (Claude Code, Codex, OpenCode, Cline) and onboard open-source projects like HyperFrames as local tools, all coordinated by the same Commander.
+- **Local-first by design** — conversations, files, API keys, knowledge bases, and custom agents all stay on your disk. Model calls go straight from your machine to the provider — never through Orkas servers.
 - **Bring your own LLM keys** — plug in Claude, OpenAI, Gemini, DeepSeek, Kimi, GLM, Qwen, MiniMax, or Doubao. Mix providers across agents. No vendor lock-in.
-- **Self-evolving** — each agent has its own private skills and memory, and improves through reflection after each task.
+- **Self-evolving workforce** — each agent has its own private skills and memory, and improves through reflection after each task.
 
 > ⭐ If Orkas is useful to you, a star helps more people find the project.
 
@@ -34,10 +35,10 @@ Orkas is an open-source, local-first desktop app: a capable **commander agent** 
 
 ## What can you build with it?
 
-- **Automate recurring reports & market research** — a sub-agent that gathers, summarizes, and ships a weekly report.
-- **Turn a product spec into dev tasks** — the commander breaks a PRD into tasks and dispatches them across agents.
+- **Automate recurring reports & market research** — a specialist agent gathers, summarizes, and ships a weekly report.
+- **Turn a product spec into dev tasks** — the Commander breaks a PRD into tasks and dispatches them across agents.
 - **Chat with your documents & run local data analysis** — drop files in, keep the data on your machine.
-- **Go beyond code — video, slides, and more** — the commander drives open-source tools like HyperFrames and hands off to CLI coding agents (Claude Code, Codex, OpenCode, Cline) and other local agents, so one chat produces code, research, video, and slide decks.
+- **Go beyond code — video, slides, and more** — the Commander drives open-source tools like HyperFrames and hands off to CLI coding agents (Claude Code, Codex, OpenCode, Cline) and other local agents, so one chat produces code, research, video, and slide decks.
 
 **Explore use cases →** [research workflows](https://orkas.ai/use/researchers?source=github) · [data analysis](https://orkas.ai/use/data-analysis?source=github) · [chat with documents](https://orkas.ai/use/chat-with-documents?source=github) · [for developers](https://orkas.ai/use/developers?source=github) · [automate your workspace](https://orkas.ai/use/automate-workspace?source=github)
 
@@ -54,13 +55,13 @@ Orkas is an open-source, local-first desktop app: a capable **commander agent** 
 
 | Tool | What it is | How Orkas differs |
 | --- | --- | --- |
-| **LangChain** | A developer framework/library for building LLM apps and agents — code-first, embedded in your own Python/JS app. | Orkas is a **no-code desktop GUI**: you assemble and command a team of agents through chat, not by writing orchestration code. Data and keys stay local by default. |
-| **CrewAI** | A Python framework for orchestrating role-playing autonomous agents — you define crews and agents in code. | Orkas gives you the same multi-agent orchestration **without code**, in a desktop app, with **local-first storage** and per-agent self-evolution built in. |
+| **LangChain** | A developer framework/library for building LLM apps and agents — code-first, embedded in your own Python/JS app. | Orkas is a local-first AI workforce you direct through chat, not by writing orchestration code. Data and keys stay local by default. |
+| **CrewAI** | A Python framework for orchestrating role-playing autonomous agents — you define crews and agents in code. | Orkas brings multi-agent orchestration into a desktop app, with **local-first storage** and per-agent self-evolution built in. |
 | **Cloud agent platforms** (SaaS orchestrators) | Server-hosted; conversations, files, and API keys live on the vendor's infrastructure. | Orkas is **local-first**: everything stays on your machine, and model API calls go straight to the provider — never archived by Orkas. |
-| **OpenClaw** | A single always-on personal assistant reaching you across messaging channels. | Orkas builds a *team* of specialized agents directed from one desktop chat — and OpenClaw plugs in as an Orkas CLI backend. |
-| **Hermes-Agent** | Nous Research's self-improving personal agent (TUI + multi-channel gateway). | Orkas is desktop-GUI and team-shaped, with per-agent private skills and meta-cognition — and Hermes-Agent plugs in as an Orkas CLI backend. |
+| **OpenClaw** | A single always-on personal assistant reaching you across messaging channels. | Orkas gives you a local-first AI workforce: the Commander coordinates specialist agents from one desktop chat, and OpenClaw plugs in as an Orkas CLI backend. |
+| **Hermes-Agent** | Nous Research's self-improving personal agent (TUI + multi-channel gateway). | Orkas is a desktop GUI for a local-first AI workforce, with per-agent private skills and meta-cognition — and Hermes-Agent plugs in as an Orkas CLI backend. |
 
-**Orkas is for you if** you want a *team* of agents (not one assistant), a desktop GUI with file drop-in and visual agent management, and your data, keys, and agents on your own disk rather than a vendor cloud.
+**Orkas is for you if** you want a local-first AI workforce (not one assistant), a desktop GUI with file drop-in and visual agent management, and your data, keys, and agents on your own disk rather than a vendor cloud.
 
 **Not for you if** you just want a single all-purpose chatbot, a fully hosted/cloud team where your data lives on a vendor's servers, or a pure code library to embed in your own app.
 
@@ -71,7 +72,7 @@ Orkas is an open-source, local-first desktop app: a capable **commander agent** 
 ## FAQ
 
 **What is Orkas?**
-A local-first desktop app where you command a team of AI agents from one chat. A capable commander agent does the work itself and directs specialized sub-agents — not a single chatbot, not a code framework, not a hosted SaaS.
+Orkas is an open-source, local-first AI workforce. A super-powered Commander coordinates specialist agents to complete complex work together — not a single chatbot, not a code framework, not a hosted SaaS.
 
 **Is Orkas a local LLM?**
 No. Orkas runs on your machine but calls the models you choose through your own API keys (or a local model endpoint). It orchestrates agents and tools — it is not itself a model.
@@ -83,10 +84,10 @@ On your disk. Conversations, files, knowledge bases, agents, and keys stay local
 The app is fully offline-capable — only the model calls need network. Point agents at a local model endpoint and you can run without the cloud.
 
 **Can Orkas drive Claude Code and other CLI coding agents?**
-Yes. Beyond its own commander and sub-agents, Orkas can drive external CLI coding agents — Claude Code, Codex, OpenCode, Cline — as local subprocesses, and onboard open-source projects like HyperFrames, all directed from the same chat.
+Yes. Beyond its own Commander and specialist agents, Orkas can drive external CLI coding agents — Claude Code, Codex, OpenCode, Cline — as local subprocesses, and onboard open-source projects like HyperFrames, all directed from the same chat.
 
 **How is Orkas different from Claude Desktop / CrewAI / LangChain?**
-Claude Desktop is a single assistant; CrewAI and LangChain are code-first frameworks. Orkas is a no-code desktop app that commands a *team* of agents, keeps data and keys local, and gives each agent its own private skills and memory. See the [full comparisons](https://orkas.ai/compare/orkas-vs-langchain?source=github).
+Claude Desktop is a single assistant; CrewAI and LangChain are code-first frameworks. Orkas is a local-first AI workforce: the Commander coordinates specialist agents, keeps data and keys local, and gives each agent its own private skills and memory. See the [full comparisons](https://orkas.ai/compare/orkas-vs-langchain?source=github).
 
 **Is Orkas free and open source?**
 Yes — MIT licensed. Bring your own model keys; you only ever pay your model providers.
@@ -128,16 +129,16 @@ run.cmd            # Windows
 
 ### Group chat: visibility slicing + a single scheduling primitive
 
-In one chat there's a commander, N agents, and you — but **each agent does not see the same conversation**.
+In one chat there's the Commander, N specialist agents, and you — but **each agent does not see the same conversation**.
 
 - **Visibility slicing** — the main conversation is one full jsonl; each agent only gets a slice (`from==me ∨ to∋me ∨ mentions∋me`). A worker never reads the full main conversation — saves tokens and prevents private context from leaking across agents.
-- **One scheduling primitive** — every dispatch (the commander's `dispatch_to`, the user's `@`, plan steps) funnels into the same `enqueue` primitive. No parallel routing paths.
-- **Shared plan** — when agents collaborate, the commander writes progress into one `plan.md`, visible to every member.
+- **One scheduling primitive** — every dispatch (the Commander's `dispatch_to`, the user's `@`, plan steps) funnels into the same `enqueue` primitive. No parallel routing paths.
+- **Shared plan** — when agents collaborate, the Commander writes progress into one `plan.md`, visible to every member.
 
 ### Agent dispatch: structured channels, not `@` in prose
 
-- **Structured dispatch** — commander↔agent dispatches go through the `dispatch_to({to, message})` tool call; `@` in prose is not treated as a dispatch signal (the user's `@` is still recognized — UX unchanged).
-- **Deferred wake-up** — a `dispatch_to` only stages; the recipient wakes only after the commander's turn finishes, preventing premature execution.
+- **Structured dispatch** — Commander-to-agent dispatches go through the `dispatch_to({to, message})` tool call; `@` in prose is not treated as a dispatch signal (the user's `@` is still recognized — UX unchanged).
+- **Deferred wake-up** — a `dispatch_to` only stages; the recipient wakes only after the Commander's turn finishes, preventing premature execution.
 - **Turn-based safety stop** — the runaway guard counts turns (`MAX_WORKER_TURNS=100`), not wall-clock time, so a slow-but-progressing LLM isn't killed.
 
 ### Self-evolution: `meta/` + self-managed skills

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,8 +1,8 @@
 # Orkas
 
-**在一个对话里指挥一支 AI agent 团队 —— 而不是单个聊天机器人。**
+**开源、本地优先的 AI 工作团队，用来协同完成复杂工作。**
 
-Orkas 是一个开源、本地优先的桌面应用：一个能力强的**指挥官 agent** 亲自干活，并调度专精的 sub-agent，全程用你自己的大模型 key，可完全离线运行。支持 macOS · Windows · Linux。
+Orkas 是一个开源、本地优先的 AI 工作团队。一个超强**指挥官**会协调多个专业智能体，共同完成复杂工作。它是运行在 macOS、Windows、Linux 上的桌面应用；你的对话、文件、智能体配置和模型 key 默认留在本机，模型调用直连你选择的服务商。
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](./LICENSE)
 [![Stars](https://img.shields.io/github/stars/Orkas-AI/Orkas?style=social)](https://github.com/Orkas-AI/Orkas/stargazers)
@@ -15,18 +15,19 @@ Orkas 是一个开源、本地优先的桌面应用：一个能力强的**指挥
 
 ![Orkas 演示](./resources/app-ui/demo.gif)
 
-> 一个能力强的指挥官 agent —— 具备 coding agent 的强项 —— 亲自完成硬核工作，并通过对话调度一支专精的 sub-agent 团队。无需流程图、无需编排代码。你的对话、文件和 API key 始终不离开本机。
+> 一个超强指挥官会把你的目标转成可执行路径，亲自处理通用工作，并在任务需要团队时协调专业智能体。无需流程图、无需编排代码。你的对话、文件和 API key 始终不离开本机。
 
 ---
 
 ## Orkas 是什么？
 
-- **它是什么** —— 一个桌面 GUI 应用，让你在同一个对话里指挥一支专精的 AI agent *团队*。不是单个聊天机器人，不是代码框架，也不是托管 SaaS。
-- **指挥官亲自干，而不只是派活** —— 主 agent 具备 coding agent 的强项（精细的文件读写、稳健的工具操作、工程纪律、多步与长程推理），能亲自完成工作；当任务需要一支团队时，它再调度 sub-agent 并行或串行执行。
-- **驱动开源生态** —— 接入外部 CLI coding agent（Claude Code、Codex、OpenCode、Cline），并把 HyperFrames 等开源项目作为本地工具接入 —— 于是一个指挥官就能产出代码、研究、数据、视频和幻灯片。
-- **本地优先** —— 对话、文件、API key、知识库、自定义 agent 全部留在你的硬盘上。模型调用从你的机器直连服务商，绝不经过 Orkas 服务器。
-- **自带大模型 key** —— 接入 Claude、OpenAI、Gemini、DeepSeek、Kimi、GLM、Qwen、MiniMax、Doubao，不同 agent 可混用不同服务商，无厂商锁定。
-- **自我进化** —— 每个 agent 拥有自己私有的技能与记忆，并在每次任务后通过复盘自我改进。
+- **开源、本地优先的 AI 工作团队** —— 一个桌面 GUI，让你在同一个对话里指挥多个协同工作的专业智能体。不是单个聊天机器人，不是代码框架，也不是托管 SaaS。
+- **超强指挥官** —— 指挥官理解上下文、拆解目标、选择合适的智能体、技能、连接器和工具；当没有更合适的专家时，也能直接处理分析、写作、调研、文件处理和自动化。
+- **专业智能体共同完成复杂工作** —— 智能体可以并行或串行执行，每个智能体都有自己的技能、记忆和任务上下文，复杂工作可以跨代码、研究、数据、视频和幻灯片推进。
+- **本地编排开源生态** —— 接入外部 CLI 编程智能体（Claude Code、Codex、OpenCode、Cline），并把 HyperFrames 等开源项目作为本地工具接入，全部由同一个指挥官协调。
+- **本地优先设计** —— 对话、文件、API key、知识库、自定义智能体全部留在你的硬盘上。模型调用从你的机器直连服务商，绝不经过 Orkas 服务器。
+- **自带大模型 key** —— 接入 Claude、OpenAI、Gemini、DeepSeek、Kimi、GLM、Qwen、MiniMax、Doubao，不同智能体可混用不同服务商，无厂商锁定。
+- **自我进化的工作团队** —— 每个智能体拥有自己私有的技能与记忆，并在每次任务后通过复盘自我改进。
 
 > ⭐ 如果 Orkas 对你有用，点个 star 能帮助更多人发现这个项目。
 
@@ -34,10 +35,10 @@ Orkas 是一个开源、本地优先的桌面应用：一个能力强的**指挥
 
 ## 你能用它做什么？
 
-- **自动化周期性报告与市场调研** —— 一个 sub-agent 负责收集、汇总并产出每周报告。
-- **把产品需求拆成开发任务** —— 指挥官把 PRD 拆成任务，分派给多个 agent。
+- **自动化周期性报告与市场调研** —— 一个专业智能体负责收集、汇总并产出每周报告。
+- **把产品需求拆成开发任务** —— 指挥官把 PRD 拆成任务，分派给多个智能体。
 - **与你的文档对话、做本地数据分析** —— 拖入文件，数据全程留在本机。
-- **不止于代码 —— 视频、幻灯片等** —— 指挥官可驱动 HyperFrames 等开源工具，并把任务交接给 CLI coding agent（Claude Code、Codex、OpenCode、Cline）及其他本地 agent，于是一个对话就能产出代码、研究、视频与幻灯片。
+- **不止于代码 —— 视频、幻灯片等** —— 指挥官可驱动 HyperFrames 等开源工具，并把任务交接给 CLI 编程智能体（Claude Code、Codex、OpenCode、Cline）及其他本地智能体，于是一个对话就能产出代码、研究、视频与幻灯片。
 
 **查看使用场景 →** [研究工作流](https://orkas.ai/use/researchers?source=github) · [数据分析](https://orkas.ai/use/data-analysis?source=github) · [与文档对话](https://orkas.ai/use/chat-with-documents?source=github) · [面向开发者](https://orkas.ai/use/developers?source=github) · [自动化你的工作区](https://orkas.ai/use/automate-workspace?source=github)
 
@@ -54,13 +55,13 @@ Orkas 是一个开源、本地优先的桌面应用：一个能力强的**指挥
 
 | 工具 | 它是什么 | Orkas 的不同之处 |
 | --- | --- | --- |
-| **LangChain** | 面向开发者的框架/库，用于构建 LLM 应用与 agent —— 代码优先，嵌入你自己的 Python/JS 应用中。 | Orkas 是 **无代码的桌面 GUI**：通过对话组建并指挥一支 agent 团队，而不是写编排代码。数据与 key 默认留在本地。 |
-| **CrewAI** | 一个 Python 框架，用于编排扮演角色的自治 agent —— 你用代码定义 crew 和 agent。 | Orkas 提供同样的多 agent 编排，但**无需写代码**，运行在桌面应用里，内置**本地优先存储**与每个 agent 的自我进化。 |
-| **云端 agent 平台**（SaaS 编排器） | 服务器托管；对话、文件、API key 都存在厂商的基础设施上。 | Orkas **本地优先**：一切留在你的机器上，模型 API 调用直连服务商 —— 绝不被 Orkas 归档。 |
-| **OpenClaw** | 一个常驻的单一个人助理，跨即时通讯渠道触达你。 | Orkas 在一个桌面对话里组建并指挥一支专精 agent *团队* —— 且 OpenClaw 可作为 Orkas 的 CLI 后端接入。 |
-| **Hermes-Agent** | Nous Research 的自我改进个人 agent（TUI + 多渠道网关）。 | Orkas 是桌面 GUI、团队化形态，每个 agent 拥有私有技能与元认知 —— 且 Hermes-Agent 可作为 Orkas 的 CLI 后端接入。 |
+| **LangChain** | 面向开发者的框架/库，用于构建 LLM 应用与智能体 —— 代码优先，嵌入你自己的 Python/JS 应用中。 | Orkas 是一个通过对话指挥的本地优先 AI 工作团队，而不是靠你写编排代码。数据与 key 默认留在本地。 |
+| **CrewAI** | 一个 Python 框架，用于编排扮演角色的自治智能体 —— 你用代码定义 crew 和智能体。 | Orkas 把多智能体编排带进桌面应用，内置**本地优先存储**与每个智能体的自我进化。 |
+| **云端智能体平台**（SaaS 编排器） | 服务器托管；对话、文件、API key 都存在厂商的基础设施上。 | Orkas **本地优先**：一切留在你的机器上，模型 API 调用直连服务商 —— 绝不被 Orkas 归档。 |
+| **OpenClaw** | 一个常驻的单一个人助理，跨即时通讯渠道触达你。 | Orkas 提供本地优先的 AI 工作团队：指挥官在一个桌面对话里协调多个专业智能体，且 OpenClaw 可作为 Orkas 的 CLI 后端接入。 |
+| **Hermes-Agent** | Nous Research 的自我改进个人智能体（TUI + 多渠道网关）。 | Orkas 是面向本地优先 AI 工作团队的桌面 GUI，每个智能体拥有私有技能与元认知 —— 且 Hermes-Agent 可作为 Orkas 的 CLI 后端接入。 |
 
-**如果你想要的是：**一支 agent *团队*（而非单个助理）、一个支持拖入文件与可视化管理 agent 的桌面 GUI、并希望数据/key/agent 都在自己的硬盘上而非厂商云端 —— 那么 Orkas 适合你。
+**如果你想要的是：**一个本地优先的 AI 工作团队（而非单个助理）、一个支持拖入文件与可视化管理智能体的桌面 GUI、并希望数据/key/智能体都在自己的硬盘上而非厂商云端 —— 那么 Orkas 适合你。
 
 **以下情况 Orkas 不适合你：**只想要一个万能单点聊天机器人、想要一个数据托管在厂商服务器上的全云端团队、或想要一个嵌入自己应用的纯代码库。
 
@@ -71,22 +72,22 @@ Orkas 是一个开源、本地优先的桌面应用：一个能力强的**指挥
 ## 常见问题（FAQ）
 
 **Orkas 是什么？**
-一个本地优先的桌面应用，让你在一个对话里指挥一支 AI agent 团队。一个能力强的指挥官 agent 亲自干活并调度专精的 sub-agent —— 不是单个聊天机器人，不是代码框架，也不是托管 SaaS。
+Orkas 是一个开源、本地优先的 AI 工作团队。一个超强指挥官会协调多个专业智能体，共同完成复杂工作 —— 不是单个聊天机器人，不是代码框架，也不是托管 SaaS。
 
 **Orkas 是本地大模型吗？**
-不是。Orkas 运行在你的机器上，但通过你自己的 API key（或本地模型端点）调用你选择的模型。它编排 agent 与工具，本身不是模型。
+不是。Orkas 运行在你的机器上，但通过你自己的 API key（或本地模型端点）调用你选择的模型。它编排智能体与工具，本身不是模型。
 
 **我的 API key 和数据存在哪里？**
-在你的硬盘上。对话、文件、知识库、agent 和 key 都留在本地；模型调用从你的机器直连服务商，绝不被 Orkas 代理或归档。
+在你的硬盘上。对话、文件、知识库、智能体和 key 都留在本地；模型调用从你的机器直连服务商，绝不被 Orkas 代理或归档。
 
 **Orkas 能离线用吗？**
-应用本身可完全离线运行 —— 只有模型调用需要网络。把 agent 指向本地模型端点，就能脱离云端运行。
+应用本身可完全离线运行 —— 只有模型调用需要网络。把智能体指向本地模型端点，就能脱离云端运行。
 
-**Orkas 能驱动 Claude Code 等 CLI coding agent 吗？**
-能。除了自己的指挥官与 sub-agent，Orkas 还能把外部 CLI coding agent（Claude Code、Codex、OpenCode、Cline）作为本地子进程驱动，并接入 HyperFrames 等开源项目，全部在同一个对话里指挥。
+**Orkas 能驱动 Claude Code 等 CLI 编程智能体吗？**
+能。除了自己的指挥官与专业智能体，Orkas 还能把外部 CLI 编程智能体（Claude Code、Codex、OpenCode、Cline）作为本地子进程驱动，并接入 HyperFrames 等开源项目，全部在同一个对话里指挥。
 
 **Orkas 和 Claude Desktop / CrewAI / LangChain 有什么不同？**
-Claude Desktop 是单个助理；CrewAI 和 LangChain 是代码优先的框架。Orkas 是无代码桌面应用，指挥一支 agent *团队*，数据与 key 留在本地，每个 agent 拥有私有技能与记忆。见[逐项对比](https://orkas.ai/compare/orkas-vs-langchain?source=github)。
+Claude Desktop 是单个助理；CrewAI 和 LangChain 是代码优先的框架。Orkas 是一个本地优先 AI 工作团队：指挥官协调多个专业智能体，数据与 key 留在本地，每个智能体拥有私有技能与记忆。见[逐项对比](https://orkas.ai/compare/orkas-vs-langchain?source=github)。
 
 **Orkas 免费且开源吗？**
 是的 —— MIT 许可证。自带模型 key，你只需为你的模型服务商付费。
@@ -128,26 +129,26 @@ run.cmd            # Windows
 
 ### 群聊：可见性切片 + 单一调度原语
 
-一个对话里有指挥官、N 个 agent 和你 —— 但**每个 agent 看到的对话并不相同**。
+一个对话里有指挥官、N 个专业智能体和你 —— 但**每个智能体看到的对话并不相同**。
 
-- **可见性切片** —— 主对话是一份完整 jsonl；每个 agent 只拿到属于自己的切片（`from==me ∨ to∋me ∨ mentions∋me`）。worker 永远读不到完整主对话 —— 既省 token，又防止私有上下文在 agent 间泄漏。
+- **可见性切片** —— 主对话是一份完整 jsonl；每个智能体只拿到属于自己的切片（`from==me ∨ to∋me ∨ mentions∋me`）。worker 永远读不到完整主对话 —— 既省 token，又防止私有上下文在智能体间泄漏。
 - **单一调度原语** —— 每一次分派（指挥官的 `dispatch_to`、用户的 `@`、计划拆出的步骤）都汇入同一个 `enqueue` 原语，没有并行的路由路径。
-- **共享计划** —— 多 agent 协作时，指挥官把进度写进同一份 `plan.md`，对每个成员可见。
+- **共享计划** —— 多智能体协作时，指挥官把进度写进同一份 `plan.md`，对每个成员可见。
 
-### Agent 分派：结构化通道，而非散文里的 `@`
+### 智能体分派：结构化通道，而非散文里的 `@`
 
-- **结构化分派** —— 指挥官与 agent 之间的分派必须走 `dispatch_to({to, message})` 工具调用；散文里的 `@` 不被识别为分派信号（用户的 `@` 仍按文本识别 —— 用户体验不变）。
+- **结构化分派** —— 指挥官与智能体之间的分派必须走 `dispatch_to({to, message})` 工具调用；散文里的 `@` 不被识别为分派信号（用户的 `@` 仍按文本识别 —— 用户体验不变）。
 - **延迟唤醒** —— 一次 `dispatch_to` 只做暂存；接收方 worker 要等指挥官当前回合结束后才被唤醒，避免过早执行。
 - **基于回合的安全停止** —— 失控保护计的是回合数（`MAX_WORKER_TURNS=100`）而非墙钟时间，因此一个慢但在推进的 LLM 不会被误杀。
 
 ### 自我进化：`meta/` + 自管理技能
 
-每个 agent 在自己的目录里维护：
+每个智能体在自己的目录里维护：
 
 - **`meta/COMPETENCE.md`** —— 我擅长什么 / 不擅长什么。
 - **`meta/LEARNING_STRATEGIES.md`** —— 对我有效的方法。
 
-每次任务后 agent 复盘并更新它们；下次任务时 `meta/` 会作为系统提示的一部分回喂进去，让经验真正影响下一次运行。通过 `skill_manage` 工具，agent 还能把"我是如何解决 X 的"结晶成一个**私有**技能，下次直接复用。
+每次任务后智能体复盘并更新它们；下次任务时 `meta/` 会作为系统提示的一部分回喂进去，让经验真正影响下一次运行。通过 `skill_manage` 工具，智能体还能把"我是如何解决 X 的"结晶成一个**私有**技能，下次直接复用。
 
 ---
 


### PR DESCRIPTION
## Summary
- Align English README around the open-source, local-first AI workforce positioning
- Localize the Chinese README with consistent terms: AI 工作团队、指挥官、专业智能体
- Remove no-code positioning from the comparison copy

## Validation
- git diff --check