### PR TITLE
Allow produced-file footer scroll chaining

### DIFF
--- a/src/renderer/style.css
+++ b/src/renderer/style.css
@@ -5921,7 +5921,9 @@ body.model-not-configured .main-content { flex-direction: column; }
 .chat-msg-produced.is-expanded {
   max-height: 168px;
   overflow-y: auto;
-  overscroll-behavior: contain;
+  /* Let wheel input reach the conversation history when this footer does not
+     overflow or has reached a scroll boundary. */
+  overscroll-behavior: auto;
   padding-right: 2px;
   scrollbar-gutter: stable;
 }

--- a/test/renderer/conversation-produced-chips.test.ts
+++ b/test/renderer/conversation-produced-chips.test.ts
@@ -55,6 +55,7 @@ describe('conversation produced chips', () => {
     expect(styleSource).toContain('.chat-msg-produced.is-expanded');
     expect(styleSource).toContain('max-height: 168px;');
     expect(styleSource).toContain('overflow-y: auto;');
+    expect(styleSource).toContain('overscroll-behavior: auto;');
   });
 
   it('dedupes same-basename chips to the more specific final path', () => {


### PR DESCRIPTION
## Summary

- let wheel input continue into conversation history when an expanded produced-file footer reaches its scroll boundary
- keep the footer independently scrollable while it still has content to consume
- add a renderer regression assertion for the CSS contract

## Verification

- `node node_modules/vitest/vitest.mjs run test/renderer/conversation-produced-chips.test.ts --reporter=dot` (4 tests passed)
- `npm run typecheck`
- OSS sync postcheck (0 forbidden symbols/files/provider-guard/orphan-import/UI/package failures)