### PR TITLE
Add BlueSkyID666 as a contributor

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,14 @@ After each task the agent reflects and updates these; on the next task `meta/` i
 
 ---
 
+## Contributors
+
+Thanks to the people who help improve Orkas:
+
+- [BlueSkyID666](https://github.com/BlueSkyID666)
+
+---
+
 ## Acknowledgments
 
 Some core modules draw on these open-source projects — special thanks to:

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -152,6 +152,14 @@ run.cmd            # Windows
 
 ---
 
+## 贡献者
+
+感谢帮助改进 Orkas 的贡献者：
+
+- [BlueSkyID666](https://github.com/BlueSkyID666)
+
+---
+
 ## 致谢
 
 本项目部分核心模块参考了以下开源项目，特此致谢：


### PR DESCRIPTION
## Summary

- add a Contributors section to the English README
- add the matching 贡献者 section to the Simplified Chinese README
- credit and link `BlueSkyID666`

## Authorship

The commit is authored with the GitHub-linked noreply identity for `BlueSkyID666` so GitHub can attribute it correctly after merge.

## Validation

- `git diff --check`
- documentation-only change; no runtime behavior changed