### PR TITLE
fix(agents): prefer Windows CLI launchers

### DIFF
--- a/src/main/features/local_agents/which.ts
+++ b/src/main/features/local_agents/which.ts
@@ -11,8 +11,9 @@
  *
  * Windows: scan PATH (split by ';'), multiply each candidate by
  * `process.env.PATHEXT` (e.g. `.COM;.EXE;.BAT;.CMD`); first stat hit
- * wins. The empty extension is also tried first because some installs
- * drop bare names (PowerShell shims, MinGW, etc.).
+ * wins. The empty extension is tried only as a fallback because npm installs
+ * a POSIX shell shim beside the Windows `.cmd` launcher; selecting that bare
+ * file makes an otherwise valid CLI fail its version probe.
  */
 
 import * as fs from 'node:fs/promises';
@@ -78,8 +79,9 @@ function uniqueDirs(dirs: string[]): string[] {
 }
 
 /**
- * Returns the candidate extensions to try on Windows, with the empty
- * extension first so an exact-name hit (rare but possible) short-circuits.
+ * Returns the candidate extensions to try on Windows. Follow PATHEXT first,
+ * matching normal Windows command resolution, then retain the empty extension
+ * as a fallback for uncommon native/MinGW installs that use a bare filename.
  */
 function winExtCandidates(): string[] {
   const raw = process.env.PATHEXT ?? '.COM;.EXE;.BAT;.CMD';
@@ -87,8 +89,7 @@ function winExtCandidates(): string[] {
     .split(';')
     .map(s => s.trim())
     .filter(Boolean);
-  // Always try the bare name first.
-  return ['', ...exts];
+  return [...exts, ''];
 }
 
 /**

--- a/test/main/features/local_agents/which.test.ts
+++ b/test/main/features/local_agents/which.test.ts
@@ -98,14 +98,24 @@ describe('local_agents/which › whichBin', () => {
       expect((await whichBin('fallback'))?.toLowerCase()).toBe(binPath.toLowerCase());
     });
 
-    it('prefers an exact bare Windows command before PATHEXT variants', async () => {
+    it('prefers a PATHEXT command over a sibling bare POSIX shim', async () => {
       const bare = path.join(tmpDir, 'tool');
+      const cmd = path.join(tmpDir, 'tool.CMD');
       fs.writeFileSync(bare, 'bare');
-      fs.writeFileSync(path.join(tmpDir, 'tool.CMD'), '@echo cmd\r\n');
+      fs.writeFileSync(cmd, '@echo cmd\r\n');
       process.env.PATH = tmpDir;
       process.env.PATHEXT = '.CMD';
 
-      expect((await whichBin('tool'))?.toLowerCase()).toBe(bare.toLowerCase());
+      expect((await whichBin('tool'))?.toLowerCase()).toBe(cmd.toLowerCase());
+    });
+
+    it('falls back to an exact bare Windows command when no PATHEXT variant exists', async () => {
+      const bare = path.join(tmpDir, 'bare-tool');
+      fs.writeFileSync(bare, 'bare');
+      process.env.PATH = tmpDir;
+      process.env.PATHEXT = '.EXE;.CMD';
+
+      expect((await whichBin('bare-tool'))?.toLowerCase()).toBe(bare.toLowerCase());
     });
 
     it('accepts forward-slash explicit paths on Windows', async () => {


### PR DESCRIPTION
## Summary

- follow PATHEXT order before trying extensionless names on Windows
- avoid selecting npm's sibling POSIX shim instead of the runnable `.cmd` launcher
- preserve extensionless commands as a fallback when no PATHEXT variant exists

## Validation

- `npm run test:js -- test/main/features/local_agents/which.test.ts` (11 non-Windows cases passed locally; the Windows-only assertions require Windows verification)
- `npm run typecheck`
- `npm run smoke` with an isolated workspace
- `git diff --check`
- Orkas sync precheck: both changed paths are shared and have no strip targets
- OSS boundary scan: 0 forbidden symbols/files, provider/API paths, orphan imports, UI invariants, credit-gated connector violations, or package violations

Source fix: Orkas commit `6a04c05c8732aa5f1ce963c6c6d72ca0b0e2c456`