### PR TITLE
fix(skills): propagate module semantic failures

### DIFF
--- a/bin/run-skill.cjs
+++ b/bin/run-skill.cjs
@@ -59,7 +59,9 @@
  *   ELECTRON_RUN_AS_NODE  — set to 1 when running through Electron binary.
  *
  * This file is CommonJS so it can be required directly without import-hook
- * gymnastics. .ts skill scripts use ESM-style default export.
+ * gymnastics. .ts skill scripts use ESM-style default export. Module scripts
+ * may return a top-level `{ ok: false }` result to report a semantic failure;
+ * the runner preserves that JSON on stdout and exits non-zero.
  */
 
 'use strict';
@@ -859,7 +861,15 @@ async function runAsModule(scriptPath, scriptArgs, skillId) {
 
   // If the script already printed structured output, respect that and skip
   // appending a duplicate payload. Convention: non-undefined return => we
-  // JSON.stringify it to stdout (trailing newline).
+  // JSON.stringify it to stdout (trailing newline). A top-level `ok: false`
+  // is the module contract for a semantic failure, so callers receive both
+  // the structured report and a failing process status.
+  const exitCode = (
+    result !== null
+    && typeof result === 'object'
+    && !Array.isArray(result)
+    && result.ok === false
+  ) ? 1 : 0;
   if (result !== undefined) {
     try {
       process.stdout.write(JSON.stringify(result) + '\n');
@@ -867,7 +877,7 @@ async function runAsModule(scriptPath, scriptArgs, skillId) {
       die(73, `failed to serialize result: ${e && e.message}`);
     }
   }
-  process.exit(0);
+  process.exit(exitCode);
 }
 
 async function main() {

--- a/test/main/util/run-skill.test.ts
+++ b/test/main/util/run-skill.test.ts
@@ -132,6 +132,50 @@ describe('run-skill.cjs', () => {
     expect(JSON.parse(r.stdout.trim())).toEqual({ ok: true, argv: 'reddit' });
   });
 
+  it('exits non-zero while preserving a module semantic-failure report', () => {
+    const skillDir = path.join(tmpDir, 'u1', 'local', 'marketplace', 'skills', 'module-failure');
+    fs.mkdirSync(path.join(skillDir, 'scripts'), { recursive: true });
+    fs.writeFileSync(
+      path.join(skillDir, 'SKILL.md'),
+      '---\nname: module-failure\ndescription: semantic failure fixture\n---\n\nbody\n',
+    );
+    fs.writeFileSync(
+      path.join(skillDir, 'scripts', 'validate.mjs'),
+      'export default async () => ({ ok: false, errors: ["artifact is invalid"] });\n',
+    );
+
+    const r = runSkill('module-failure', 'validate');
+
+    expect(r.status).toBe(1);
+    expect(r.stderr).toBe('');
+    expect(JSON.parse(r.stdout.trim())).toEqual({
+      ok: false,
+      errors: ['artifact is invalid'],
+    });
+  });
+
+  it('does not infer failure from module-specific fields without ok false', () => {
+    const skillDir = path.join(tmpDir, 'u1', 'local', 'marketplace', 'skills', 'module-result');
+    fs.mkdirSync(path.join(skillDir, 'scripts'), { recursive: true });
+    fs.writeFileSync(
+      path.join(skillDir, 'SKILL.md'),
+      '---\nname: module-result\ndescription: module result fixture\n---\n\nbody\n',
+    );
+    fs.writeFileSync(
+      path.join(skillDir, 'scripts', 'inspect.js'),
+      'module.exports = async () => ({ valid: false, reason: "informational result" });\n',
+    );
+
+    const r = runSkill('module-result', 'inspect');
+
+    expect(r.status).toBe(0);
+    expect(r.stderr).toBe('');
+    expect(JSON.parse(r.stdout.trim())).toEqual({
+      valid: false,
+      reason: 'informational result',
+    });
+  });
+
   it('keeps direct internal-id lookup working', () => {
     writeMarketplaceSkill('252af214f470', 'social-fetch', 'fetch');
 


### PR DESCRIPTION
## Summary

- treat a module Skill result with top-level `ok: false` as a semantic failure
- preserve the structured JSON report on stdout while returning exit code 1
- keep module-specific fields such as `valid: false` informational unless `ok` is explicitly false

## Validation

- `npm run test:js -- test/main/util/run-skill.test.ts` (13 passed, 2 unrelated platform cases skipped)
- `npm run typecheck`
- `git diff --check`
- Orkas sync precheck: private docs and eval coverage excluded; shared runner and deterministic regression coverage retained

Source fix: Orkas commit `76511973d1380e501e29138f7f4097c1234778f0`