### PR TITLE
fix(core-agent): keep retry display attempts monotonic

### DIFF
--- a/src/core-agent/src/agent/runner.ts
+++ b/src/core-agent/src/agent/runner.ts
@@ -916,6 +916,10 @@ export class AgentRunner {
     const skillsLoadedSet = new Set<string>();
     let transientToolErrors = 0;
     let permanentToolErrors = 0;
+    // Provider wrappers and AgentRunner own separate retry budgets, but the
+    // public stream is one user-visible task. Normalize both sources here so
+    // the process rail never regresses from (for example) retry 3 to retry 1.
+    let visibleRetryAttempt = 0;
     const timings: MutableRunTimings = {
       providerMs: 0,
       toolMs: 0,
@@ -1116,7 +1120,8 @@ export class AgentRunner {
             }
             streamingTool = null;
           } else if (ev.type === "retry") {
-            yield { type: "retry", attempt: ev.attempt, reason: ev.reason };
+            visibleRetryAttempt += 1;
+            yield { type: "retry", attempt: visibleRetryAttempt, reason: ev.reason };
           } else if (ev.type === "provider_fallback") {
             yield {
               type: "provider_fallback",
@@ -2041,7 +2046,8 @@ export class AgentRunner {
           const waitMs = retryDelayMs(err, attempt);
           const reason = formatError(err);
           log.warn(`Retryable ${retryKind} error (attempt ${attempt + 1}/${maxRetries}): ${reason}, waiting ${waitMs}ms`);
-          yield { type: "retry", attempt: attempt + 1, reason, waitMs };
+          visibleRetryAttempt += 1;
+          yield { type: "retry", attempt: visibleRetryAttempt, reason, waitMs };
           const retryWaitStartedAt = Date.now();
           await sleep(waitMs, params.signal);
           timings.retryWaitMs += Math.max(0, Date.now() - retryWaitStartedAt);

--- a/src/core-agent/test/agent-runner.test.ts
+++ b/src/core-agent/test/agent-runner.test.ts
@@ -1379,6 +1379,57 @@ describe("AgentRunner", () => {
     expect(attempts).toEqual([0, 1]);
   });
 
+  it("keeps visible retry ordinals monotonic across provider and outer recovery layers", async () => {
+    const agentAttempts: number[] = [];
+    let streamCalls = 0;
+    const mockProvider: LLMProvider = {
+      id: "mock",
+      name: "Mock",
+      async complete() { throw new Error("complete not used"); },
+      async *stream(params) {
+        agentAttempts.push(params.retryContext?.agentAttempt ?? -1);
+        streamCalls += 1;
+        if (streamCalls === 1) {
+          // Each provider candidate and auth route owns a local attempt
+          // counter. This mirrors the production timeline that exposed the
+          // visible 3 -> 1 and 3 -> 1 regressions.
+          for (const attempt of [1, 2, 3, 1, 2, 3, 1, 2]) {
+            yield { type: "retry" as const, attempt, reason: "fetch failed" };
+          }
+        }
+        if (streamCalls === 1) throw new RateLimitError("retry immediately", 0);
+        yield { type: "text_delta" as const, text: "recovered" };
+        yield {
+          type: "message_end" as const,
+          stopReason: "end_turn" as const,
+          usage: { inputTokens: 4, outputTokens: 2, totalTokens: 6 },
+          content: [{ type: "text" as const, text: "recovered" }],
+          model: "mock-model",
+        };
+      },
+      async validateAuth() { return true; },
+    };
+    const registry = new ProviderRegistry();
+    registry.registerFactory("mock", () => mockProvider);
+    const config = createConfig({
+      agent: { defaultProvider: "mock", defaultModel: "mock-model", maxRetries: 2 },
+    });
+    const runner = new AgentRunner({ config, providers: registry, tools: [] });
+    const events: AgentRunEvent[] = [];
+
+    for await (const event of runner.runStream({ message: "recover across both layers" })) {
+      events.push(event);
+    }
+
+    expect(events.filter((event) => event.type === "retry").map((event) => event.attempt))
+      .toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9]);
+    expect(agentAttempts).toEqual([0, 1]);
+    expect(events.at(-1)).toMatchObject({
+      type: "done",
+      result: { text: "recovered", meta: { stopReason: "end_turn" } },
+    });
+  });
+
   it("stops immediately when storage is full", async () => {
     let streamCalls = 0;
     const mockProvider: LLMProvider = {


### PR DESCRIPTION
## Summary

- keep displayed retry attempt numbers monotonic across provider and runner retry layers
- preserve the existing retry budgets and retry reasons at each layer
- add regression coverage for a combined retry timeline

## Testing

- `node scripts/run-tests.mjs run src/core-agent/test/agent-runner.test.ts` (63 passed)
- `npm run typecheck`
- `npm run smoke`
- `npm test` (3 unrelated baseline failures, reproduced on `origin/main`; 5854 passed, 15 skipped)
- resource tests unavailable in this environment because `pytest` is not installed