### PR TITLE
fix(chat): play local media paths in markdown

### DIFF
--- a/src/main/model/core-agent/video-studio-tool.ts
+++ b/src/main/model/core-agent/video-studio-tool.ts
@@ -95,6 +95,7 @@ import {
 import { probeMediaDurationSec } from '../../util/media_probe';
 import { bundledFfmpegPaths, bundledWhisperPaths } from '../../util/bundled-runtime';
 import { isPathAllowed } from '../../util/path-sandbox';
+import { chatMediaLocalUrl } from '../../util/chat-media-url';
 import { uniquifyPath, renderRenameSignal } from '../../util/uniquify-path';
 import { getWorkspacePath } from '../../features/user_workspace';
 import { decodeSubmission } from '../../features/group_chat/router';
@@ -7154,6 +7155,9 @@ export function createVideoStudioTool(opts: VideoStudioToolOpts): AgentTool {
               confirmation_required: false,
             },
             ...(result.ok ? { next_action: 'deliver_final' } : {}),
+            ...(result.ok && outputAbsPath
+              ? { deliver_markdown: `[${path.basename(outputAbsPath)}](${chatMediaLocalUrl(outputAbsPath)})` }
+              : {}),
           } as typeof result;
         }
 

--- a/src/renderer/modules/utils.js
+++ b/src/renderer/modules/utils.js
@@ -1151,6 +1151,34 @@ function _chatMediaLocalPathFromUrl(src) {
   }
 }
 
+// Rewrite local paths into the private protocol that validates and serves
+// local media under its existing extension and size gates. Relative paths stay
+// unchanged because the renderer has no workspace base from which to resolve them.
+function _normalizeLocalMediaSrc(src) {
+  const raw = String(src === null || src === undefined ? '' : src).trim();
+  if (!raw) return raw;
+  if (/^(?:chat-media|https?|data|blob|kb-file|chat-app):/i.test(raw)) return raw;
+
+  let abs = '';
+  if (/^file:/i.test(raw)) {
+    try {
+      const decoded = decodeURIComponent(new URL(raw).pathname || '');
+      abs = /^\/[A-Za-z]:[\\/]/.test(decoded) ? decoded.slice(1) : decoded;
+    } catch (_) { return raw; }
+  } else {
+    const bare = raw.replace(/^sandbox:/i, '');
+    if (bare.startsWith('/') || /^[A-Za-z]:[\\/]/.test(bare)) abs = bare;
+  }
+  if (!abs) return raw;
+
+  let normalized = abs.includes('\\') ? abs.replace(/\\/g, '/') : abs;
+  if (normalized.startsWith('/')) normalized = normalized.slice(1);
+  const encoded = normalized.split('/').map((segment, index) => (
+    index === 0 && /^[A-Za-z]:$/.test(segment) ? segment : encodeURIComponent(segment)
+  )).join('/');
+  return `chat-media://local/${encoded}`;
+}
+
 function _markdownVideoOpenFloatingLabel() {
   const key = 'chat.video_open_floating_title';
   try {
@@ -1465,7 +1493,8 @@ function inlineFormat(text) {
     // Media: ![alt](src) — dispatch to <video> when src looks like a video
     // file, else <img>. Must run before link syntax.
     .replace(/!\[([^\]]*)\]\(([^)\s]+)(?:\s+"([^"]*)")?\)/g,
-      (_, alt, src, title) => {
+      (_, alt, rawSrc, title) => {
+        const src = _normalizeLocalMediaSrc(rawSrc);
         if (_isVideoSrc(src)) {
           // `preload=metadata` so listings don't auto-fetch the whole file;
           // controls visible so user can play/seek.
@@ -1476,7 +1505,10 @@ function inlineFormat(text) {
       })
     // Markdown links: [text](url "title")
     .replace(/\[([^\]]+)\]\(([^)\s]+)(?:\s+"([^"]*)")?\)/g,
-      (_, txt, url, title) => {
+      (_, txt, rawUrl, title) => {
+        const url = _isVideoSrc(rawUrl) || _isAudioSrc(rawUrl)
+          ? _normalizeLocalMediaSrc(rawUrl)
+          : rawUrl;
         if (_isVideoSrc(url)) return _markdownVideoHtml(url, txt, title);
         if (_isAudioSrc(url)) return _markdownAudioHtml(url, txt, title);
         // href: scheme-checked + escaped (blocks javascript:/data: and quote
@@ -1974,6 +2006,7 @@ if (typeof module !== 'undefined' && typeof module.exports === 'object') {
     _markdownVideoHtml,
     _markdownAudioHtml,
     _chatMediaLocalPathFromUrl,
+    _normalizeLocalMediaSrc,
     _chatVideoNativeControlsHit,
     escapeHtml,
     sanitizeHtml,

--- a/test/main/model/core-agent/video-studio-state-tool.test.ts
+++ b/test/main/model/core-agent/video-studio-state-tool.test.ts
@@ -3181,6 +3181,10 @@ describe('VideoStudio production-state tool protocol', () => {
     expect(result.isError).toBe(false);
     expect(fs.readFileSync(finalPath, 'utf8')).toBe('clean final');
     expect(events).toEqual(['render', 'written', 'published']);
+    expect(parseResult(result.content)).toMatchObject({
+      next_action: 'deliver_final',
+      deliver_markdown: `[final.mp4](chat-media://local${finalPath})`,
+    });
   });
 
   it('enforces Gate B and prevents authored visuals from bypassing pending narration', async () => {

--- a/test/renderer/utils-autolink.test.ts
+++ b/test/renderer/utils-autolink.test.ts
@@ -27,6 +27,7 @@ const {
   _markdownVideoHtml,
   _markdownAudioHtml,
   _chatMediaLocalPathFromUrl,
+  _normalizeLocalMediaSrc,
   _chatVideoNativeControlsHit,
 } = utils as {
   _BARE_URL_RE: RegExp;
@@ -36,6 +37,7 @@ const {
   _markdownVideoHtml: (src: string, label: string, title?: string) => string;
   _markdownAudioHtml: (src: string, label: string, title?: string) => string;
   _chatMediaLocalPathFromUrl: (src: string) => string;
+  _normalizeLocalMediaSrc: (src: string) => string;
   _chatVideoNativeControlsHit: (clientY: number, rectTop: number, rectBottom: number) => boolean;
 };
 
@@ -186,6 +188,37 @@ describe('markdown media links', () => {
     expect(out).toContain('data-video-src="chat-media://local/Users/test/car_driving.mp4"');
     expect(out).toContain('aria-label="Fullscreen"');
     expect(out).not.toContain('<a ');
+  });
+
+  it('plays local media delivered with a sandbox, file, or absolute path', () => {
+    const sources = [
+      'sandbox:/Users/test/render/final.mp4',
+      '/Users/test/render/final.mp4',
+      'file:///Users/test/render/final.mp4',
+    ];
+
+    for (const src of sources) {
+      for (const markdown of [`[video](${src})`, `![video](${src})`]) {
+        const out = inlineFormat(markdown);
+        expect(out, markdown).toContain('src="chat-media://local/Users/test/render/final.mp4"');
+        expect(out, markdown).toContain('<video class="chat-md-video"');
+        expect(out, markdown).toContain('data-chat-md-video-open="1"');
+        expect(out, markdown).not.toContain('sandbox:');
+      }
+    }
+  });
+
+  it('leaves remote and unresolved media paths unchanged', () => {
+    expect(inlineFormat('![figure](images/figure.png)')).toContain('src="images/figure.png"');
+    expect(inlineFormat('[clip](https://example.test/a.mp4)'))
+      .toContain('src="https://example.test/a.mp4"');
+    expect(inlineFormat('[clip](chat-media://local/Users/test/a.mp4)'))
+      .toContain('src="chat-media://local/Users/test/a.mp4"');
+    expect(inlineFormat('[notes](sandbox:/Users/test/notes.txt)')).not.toContain('chat-media://');
+    expect(_normalizeLocalMediaSrc('C:\\Users\\test\\render\\clip.mp4'))
+      .toBe('chat-media://local/C:/Users/test/render/clip.mp4');
+    expect(_normalizeLocalMediaSrc('/Users/test/has space.mp4'))
+      .toBe('chat-media://local/Users/test/has%20space.mp4');
   });
 
   it('escapes markdown video attributes', () => {


### PR DESCRIPTION
## Summary

- normalize sandbox:, file://, POSIX, and Windows absolute media paths through the existing chat-media://local protocol
- return a ready-to-use deliver_markdown link after a successful VideoStudio export
- keep relative paths and remote URLs unchanged; the existing protocol extension, size, and SVG safety gates remain in force

## Source review

This ports the shared Orkas fix from b0fb8cf69 after an open-source boundary review. The private regression document was excluded, release-only generated-provider references were not copied, and the original fix author is preserved on the commit.

A negative control against origin/main reproduced three failures: sandbox media remained unservable, the normalizer was absent, and VideoStudio omitted the delivery link.

## Testing

- node scripts/run-tests.mjs run test/renderer/utils-autolink.test.ts test/main/model/core-agent/video-studio-state-tool.test.ts (103 passed)
- related media/chat suite (248 passed)
- npm run typecheck
- node --check src/renderer/modules/utils.js
- npm run smoke
- npm test -- --reporter=dot (5855 passed, 15 skipped; 3 unrelated baseline failures in builtin marketplace tombstone and bundled runtime path cases)
- OSS sync postcheck reported zero forbidden symbols, provider/API changed-file violations, and orphan imports for this diff; the repository-wide check remains blocked by 11 pre-existing main-branch sync violations