### PR TITLE
fix(chat): keep selected task mounted

### DIFF
--- a/src/renderer/modules/boot.js
+++ b/src/renderer/modules/boot.js
@@ -416,8 +416,7 @@ function setView(view, cid, opts = {}) {
   }
   if (view === 'conversation' && cid) {
     currentCid = cid;
-    // Opening the task is the read boundary for its completed reply. This also
-    // runs when the already-selected row is clicked again.
+    // Opening the task is the read boundary for its completed reply.
     if (typeof _markConversationRead === 'function') _markConversationRead(cid);
     // Bind the video review drawer to the conversation being shown, here rather
     // than inside loadConversationHistory. Only one of the three branches below

--- a/src/renderer/modules/conversation.js
+++ b/src/renderer/modules/conversation.js
@@ -6054,10 +6054,15 @@ function _bindConversationSidebarItems(container, opts = {}) {
     el.addEventListener('click', (e) => {
       if (e.target.closest('.conv-item-title-input')) return;
       if (e.target.closest('.conv-item-action')) return;
+      const cid = el.dataset.cid;
+      // The selected task is already mounted. Re-entering it would rebuild
+      // the transcript, reset its scroll position, refresh attachments, and
+      // steal composer focus even though the user's destination did not change.
+      if (currentView === 'conversation' && currentCid === cid) return;
       _convTrackClick('sidebar_conversation_open', {
         scope: selector.includes('nested') ? 'project' : 'unprojected',
       });
-      setView('conversation', el.dataset.cid);
+      setView('conversation', cid);
     });
   });
   container.querySelectorAll('.conv-item-menu').forEach(btn => {

--- a/test/renderer/conversation-sidebar.test.ts
+++ b/test/renderer/conversation-sidebar.test.ts
@@ -412,6 +412,37 @@ describe('conversation run observer cleanup', () => {
 });
 
 describe('conversation sidebar task row actions', () => {
+  it('keeps the selected task mounted while other task rows still navigate', () => {
+    const context = loadConversationRenderer();
+    const navigations: Array<[string, string]> = [];
+    let rowClick: ((event: any) => void) | null = null;
+    const row: any = {
+      dataset: { cid: 'c1' },
+      addEventListener(type: string, listener: (event: any) => void) {
+        if (type === 'click') rowClick = listener;
+      },
+    };
+    const container: any = {
+      querySelectorAll(selector: string) {
+        return selector === '.conv-item' ? [row] : [];
+      },
+    };
+    const event = { target: { closest: () => null } };
+    context.currentView = 'conversation';
+    context.currentCid = 'c1';
+    context.setView = (view: string, cid: string) => { navigations.push([view, cid]); };
+
+    context._bindConversationSidebarItems(container);
+    expect(rowClick).not.toBeNull();
+
+    rowClick!(event);
+    expect(navigations).toEqual([]);
+
+    row.dataset.cid = 'c2';
+    rowClick!(event);
+    expect(navigations).toEqual([['conversation', 'c2']]);
+  });
+
   it('renders a single menu button after the title', () => {
     const context = loadConversationRenderer();
     const html = context._renderConversationSidebarItem({


### PR DESCRIPTION
## Summary

- ignore repeat clicks on the task that is already mounted
- preserve the transcript, scroll position, composer attachments/draft, and focus
- keep navigation to every other task unchanged

## Testing

- `node scripts/run-tests.mjs run test/renderer/conversation-sidebar.test.ts` — 278 passed
- `npm run typecheck` — passed
- renderer `node --check` and `git diff --check` — passed
- `npm test` — 504 files / 7,371 tests passed, 15 skipped; two unrelated baseline failures reproduced on unmodified `origin/main`: the video script fixture cannot create `/Users/userWorkSpace` in this environment, and the local OfficeCLI binary hash differs from the repository pin