### PR TITLE
fix(core-agent): account for image context tokens

### DIFF
--- a/src/core-agent/src/agent/session.ts
+++ b/src/core-agent/src/agent/session.ts
@@ -37,6 +37,14 @@ export {
   type ContextBudget,
 } from "./context-budget.js";
 
+/** Flat per-image estimate. Real cost is dimension-dependent — Anthropic caps
+ *  around 1,600 tokens per image and OpenAI high-detail lands nearby — but the
+ *  estimator only needs to stop pricing a thousand-token block at zero: the
+ *  request-token anchor corrects to provider truth at the next completed call,
+ *  overestimating merely compacts a little early, and underestimating is an
+ *  overflow. Dimension-aware costing is deliberately not attempted. */
+export const IMAGE_BLOCK_ESTIMATE_TOKENS = 1_600;
+
 export const HISTORY_SUMMARY_MAX_TOKENS = 2_048;
 export const HISTORY_EXACT_FACTS_HEADING =
   "Exact facts and identifiers required across turns (cumulative):";
@@ -2868,6 +2876,7 @@ function sumMessageTokens(messages: Message[]): number {
       if (c.type === "text") total += estimateTextTokens(c.text);
       else if (c.type === "tool_result") total += estimateTextTokens(c.content);
       else if (c.type === "tool_use") total += estimateTextTokens(JSON.stringify(c.input));
+      else if (c.type === "image") total += IMAGE_BLOCK_ESTIMATE_TOKENS;
     }
   }
   return total;

--- a/src/core-agent/test/session.test.ts
+++ b/src/core-agent/test/session.test.ts
@@ -14,6 +14,7 @@ import {
   HISTORY_EXACT_FACTS_HEADING,
   HISTORY_EXACT_FACTS_MAX_ITEMS,
   HISTORY_RAW_RETAIN_TOKEN_BUDGET,
+  IMAGE_BLOCK_ESTIMATE_TOKENS,
   DEFAULT_CONTEXT_BUDGET,
   contextBudget,
 } from "../src/agent/session.js";
@@ -1219,6 +1220,41 @@ describe("Session", () => {
     const flat = msgs.flatMap((m) => m.content);
     expect(flat.some((c) => (c as { type?: string }).type === "tool_use" && (c as { id?: string }).id === "call-Z")).toBe(true);
     expect(flat.some((c) => (c as { type?: string }).type === "tool_result" && (c as { toolUseId?: string }).toolUseId === "call-Z")).toBe(true);
+  });
+
+  // Image blocks cost real tokens (provider caps sit around 1,600 per image)
+  // but the estimator priced them at zero, so image-heavy turns — frame
+  // screenshots from browser/video tools — were invisible to every derived
+  // trigger and budget until the provider refused the request.
+  it("prices image blocks instead of estimating them at zero", () => {
+    const textOnly = new Session();
+    textOnly.addUserMessage("inspect the frames");
+    const withImages = new Session();
+    withImages.addMessage("user", [
+      { type: "text", text: "inspect the frames" },
+      { type: "image", data: "aW1n", mediaType: "image/png" },
+      { type: "image", data: "aW1n", mediaType: "image/png" },
+    ]);
+    expect(withImages.estimateTokens() - textOnly.estimateTokens())
+      .toBe(2 * IMAGE_BLOCK_ESTIMATE_TOKENS);
+  });
+
+  it("image-heavy tool steps reach the active checkpoint trigger", () => {
+    const session = new Session();
+    session.beginUserTurn([{ type: "text", text: "render the video frames" }]);
+    // 14 steps, each returning one screenshot: ~22K estimated tokens of
+    // images against the 18K default trigger. With images priced at zero
+    // this turn estimated as a few hundred tokens and never produced a
+    // checkpoint candidate while the real request kept growing.
+    for (let i = 0; i < 14; i++) {
+      session.addAssistantMessage([{ type: "tool_use", id: `frame-${i}`, name: "screenshot", input: { frame: i } }]);
+      session.addToolResult(`frame-${i}`, `frame ${i} captured`, [
+        { data: "aW1n", mediaType: "image/png" },
+      ]);
+    }
+    const candidate = session.getPendingActiveCheckpoint();
+    expect(candidate).not.toBeNull();
+    expect(candidate!.tokensBefore).toBeGreaterThan(ACTIVE_PROCESS_TRIGGER_TOKENS);
   });
 
   // estimateKeptTailTokens powers the runner's "skip a no-progress compaction"


### PR DESCRIPTION
## Summary

- count image content blocks in the shared session token estimator instead of pricing them at zero
- let image-heavy tool turns reach the active-checkpoint threshold before provider context overflow
- cover both direct token estimates and checkpoint triggering with regression tests

Source: Orkas commit f2c1c42d83f7b2914a247c6906adbe0ce35bfa57, adapted onto the current OrkasOpen main branch.

## Testing

- `npm run typecheck`
- `node scripts/run-tests.mjs run src/core-agent/test/session.test.ts` — 76 passed
- `node scripts/run-tests.mjs run src/core-agent/test` — 32 files / 680 tests passed
- `git diff --check`
- selective OSS postcheck: no forbidden symbols/files, provider/API changes, orphan imports, UI/package violations, or TypeScript/renderer syntax failures

## Local baseline limitations

- full `npm test`: 503 files / 7,371 tests passed; 3 environment-dependent tests failed because the local checkout lacks the OfficeCLI host binary and the existing video fixture tries to create `/Users/userWorkSpace`
- `npm run test:resources` could not start because the system Python does not have pytest installed
- the selective OSS postcheck still reports the pre-existing builtin-resource hash drift and full-sync coverage backlog; neither is changed by this two-file PR