### PR TITLE
fix(tools): align edit freshness recovery guidance

### DIFF
--- a/src/main/model/core-agent/read-tracker.ts
+++ b/src/main/model/core-agent/read-tracker.ts
@@ -81,12 +81,11 @@ export type EditBlock = { code: 'E_NOT_READ' | 'E_STALE'; msg: string };
  *   - never read this run            → E_NOT_READ
  *   - read, but mtime/size changed   → E_STALE
  *
- * Message contract: every consumer (edit_file, apply_patch) appends a
- * recovery block with the current bytes and a fresh file_hash, and refreshes
- * the read baseline on rejection — so the messages steer the model at that
- * returned context first. A bare "call read_file again" here made models pay
- * a full re-read round the trailer had already made unnecessary
- * (2026-08-16 latency review P0-4).
+ * Message contract: every consumer (edit_file, apply_patch) appends bounded
+ * current context plus its own executable recovery instruction, and refreshes
+ * the read baseline on rejection. Keep these shared messages limited to the
+ * failure reason so they cannot prescribe a parameter or workflow that one
+ * consumer does not support (2026-08-16 latency review P0-4).
  */
 export function checkEditFreshness(
   ctx: ToolContext,
@@ -109,7 +108,7 @@ export function checkEditFreshness(
   if (!seen) {
     return {
       code: 'E_NOT_READ',
-      msg: `${abs}: not read in this run, so old_string cannot be checked against the real current contents. Use the current context and file_hash returned below to retry (pass expected_hash); use read_file with a bounded range only if that window misses your target.`,
+      msg: `${abs}: not read in this run, so the proposed change cannot be checked against the real current contents. Follow the current-context recovery guidance returned below.`,
     };
   }
   if (
@@ -119,7 +118,7 @@ export function checkEditFreshness(
   ) {
     return {
       code: 'E_STALE',
-      msg: `${abs}: file changed on disk since you read it (another worker, a command, or an external edit). Retry against the current context and file_hash returned below (pass expected_hash); re-read only the affected region with read_file range if that window is insufficient.`,
+      msg: `${abs}: file changed on disk since you read it (another worker, a command, or an external edit). Follow the current-context recovery guidance returned below.`,
     };
   }
   return null;

--- a/src/main/model/core-agent/read-tracker.ts
+++ b/src/main/model/core-agent/read-tracker.ts
@@ -78,8 +78,15 @@ export type EditBlock = { code: 'E_NOT_READ' | 'E_STALE'; msg: string };
  * Decide whether `edit_file` may proceed on `abs`, given its current stat.
  * Returns null when the edit is allowed (or when the run-scoped map is absent,
  * i.e. the host opted out — see module header), otherwise the block reason:
- *   - never read this run            → E_NOT_READ (read it first)
- *   - read, but mtime/size changed   → E_STALE   (re-read; it moved under you)
+ *   - never read this run            → E_NOT_READ
+ *   - read, but mtime/size changed   → E_STALE
+ *
+ * Message contract: every consumer (edit_file, apply_patch) appends a
+ * recovery block with the current bytes and a fresh file_hash, and refreshes
+ * the read baseline on rejection — so the messages steer the model at that
+ * returned context first. A bare "call read_file again" here made models pay
+ * a full re-read round the trailer had already made unnecessary
+ * (2026-08-16 latency review P0-4).
  */
 export function checkEditFreshness(
   ctx: ToolContext,
@@ -102,7 +109,7 @@ export function checkEditFreshness(
   if (!seen) {
     return {
       code: 'E_NOT_READ',
-      msg: `${abs}: read the file with read_file before editing it, so old_string matches the real current contents.`,
+      msg: `${abs}: not read in this run, so old_string cannot be checked against the real current contents. Use the current context and file_hash returned below to retry (pass expected_hash); use read_file with a bounded range only if that window misses your target.`,
     };
   }
   if (
@@ -112,7 +119,7 @@ export function checkEditFreshness(
   ) {
     return {
       code: 'E_STALE',
-      msg: `${abs}: file changed on disk since you read it (another worker, a command, or an external edit). Call read_file again, then redo the edit against the current contents.`,
+      msg: `${abs}: file changed on disk since you read it (another worker, a command, or an external edit). Retry against the current context and file_hash returned below (pass expected_hash); re-read only the affected region with read_file range if that window is insufficient.`,
     };
   }
   return null;

--- a/test/main/model/core-agent/local-tools.test.ts
+++ b/test/main/model/core-agent/local-tools.test.ts
@@ -987,6 +987,47 @@ describe('local-tools › apply_patch › transactional text changes', () => {
     expect(fs.readFileSync(source, 'utf8')).toBe('const value = 2;\n');
   });
 
+  it('returns apply_patch-compatible recovery after E_NOT_READ and accepts a rebuilt patch', async () => {
+    await grant();
+    const { applyPatch, wsDir } = await buildPatchTool();
+    const source = path.join(wsDir, 'source.ts');
+    fs.writeFileSync(source, 'const value = 1;\nconst label = "before";\n');
+    const ctx = { workingDir: wsDir, state: { readFileState: new Map() } } as any;
+
+    const blocked = await applyPatch.execute({
+      patch: [
+        '*** Begin Patch',
+        `*** Update File: ${source}`,
+        '@@',
+        '-const label = "before";',
+        '+const label = "after";',
+        '*** End Patch',
+      ].join('\n'),
+    }, ctx);
+
+    expect(blocked.isError).toBe(true);
+    expect(blocked.content).toContain('E_NOT_READ');
+    expect(blocked.content).toContain('<patch-recovery file_hash=');
+    expect(blocked.content).toContain('rebuild the patch against these bytes');
+    expect(blocked.content).not.toContain('expected_hash');
+    expect(fs.readFileSync(source, 'utf8')).toBe('const value = 1;\nconst label = "before";\n');
+
+    const retried = await applyPatch.execute({
+      patch: [
+        '*** Begin Patch',
+        `*** Update File: ${source}`,
+        '@@',
+        ' const value = 1;',
+        '-const label = "before";',
+        '+const label = "after";',
+        '*** End Patch',
+      ].join('\n'),
+    }, ctx);
+
+    expect(retried.isError).toBeFalsy();
+    expect(fs.readFileSync(source, 'utf8')).toBe('const value = 1;\nconst label = "after";\n');
+  });
+
   it('moves an updated file while preserving its mode and reporting the destination', async () => {
     await grant();
     const { applyPatch, wsDir } = await buildPatchTool();

--- a/test/main/model/core-agent/read-tracker.test.ts
+++ b/test/main/model/core-agent/read-tracker.test.ts
@@ -53,6 +53,12 @@ describe('read-tracker › checkEditFreshness', () => {
     const st = fs.statSync(file);
     const block = checkEditFreshness(ctx, file, st);
     expect(block?.code).toBe('E_NOT_READ');
+    // The refusal steers at the recovery block every consumer appends, not at
+    // a bare full re-read: a "call read_file" instruction here made models pay
+    // a whole re-read round the returned context had already made unnecessary.
+    expect(block?.msg).toContain('expected_hash');
+    expect(block?.msg).toContain('bounded range');
+    expect(block?.msg).not.toMatch(/read the file with read_file before/);
   });
 
   it('allows the edit after a read records the baseline', () => {
@@ -80,6 +86,11 @@ describe('read-tracker › checkEditFreshness', () => {
     fs.writeFileSync(file, 'a much longer body than before', 'utf8'); // size changes
     const block = checkEditFreshness(ctx, file, fs.statSync(file));
     expect(block?.code).toBe('E_STALE');
+    // Same recovery-first contract as E_NOT_READ: retry against the returned
+    // context/hash, bounded range re-read only as the fallback.
+    expect(block?.msg).toContain('expected_hash');
+    expect(block?.msg).toContain('read_file range');
+    expect(block?.msg).not.toMatch(/Call read_file again/);
   });
 
   it('blocks with E_STALE when only mtime changed (same size)', () => {

--- a/test/main/model/core-agent/read-tracker.test.ts
+++ b/test/main/model/core-agent/read-tracker.test.ts
@@ -53,12 +53,10 @@ describe('read-tracker › checkEditFreshness', () => {
     const st = fs.statSync(file);
     const block = checkEditFreshness(ctx, file, st);
     expect(block?.code).toBe('E_NOT_READ');
-    // The refusal steers at the recovery block every consumer appends, not at
-    // a bare full re-read: a "call read_file" instruction here made models pay
-    // a whole re-read round the returned context had already made unnecessary.
-    expect(block?.msg).toContain('expected_hash');
-    expect(block?.msg).toContain('bounded range');
-    expect(block?.msg).not.toMatch(/read the file with read_file before/);
+    // The shared refusal points at each consumer's own recovery block instead
+    // of prescribing edit_file-only parameters or a redundant read round.
+    expect(block?.msg).toContain('current-context recovery guidance');
+    expect(block?.msg).not.toMatch(/expected_hash|read_file/);
   });
 
   it('allows the edit after a read records the baseline', () => {
@@ -86,11 +84,9 @@ describe('read-tracker › checkEditFreshness', () => {
     fs.writeFileSync(file, 'a much longer body than before', 'utf8'); // size changes
     const block = checkEditFreshness(ctx, file, fs.statSync(file));
     expect(block?.code).toBe('E_STALE');
-    // Same recovery-first contract as E_NOT_READ: retry against the returned
-    // context/hash, bounded range re-read only as the fallback.
-    expect(block?.msg).toContain('expected_hash');
-    expect(block?.msg).toContain('read_file range');
-    expect(block?.msg).not.toMatch(/Call read_file again/);
+    // Same consumer-neutral contract as E_NOT_READ.
+    expect(block?.msg).toContain('current-context recovery guidance');
+    expect(block?.msg).not.toMatch(/expected_hash|read_file/);
   });
 
   it('blocks with E_STALE when only mtime changed (same size)', () => {


### PR DESCRIPTION
## Summary

- align `E_NOT_READ` and `E_STALE` guidance with the recovery context already appended by `edit_file` and `apply_patch`
- let agents retry with the returned `file_hash` before falling back to a bounded `read_file` range
- add regression assertions for both freshness refusal paths

## Testing

- `npm run test:js -- test/main/model/core-agent/read-tracker.test.ts test/main/model/core-agent/local-tools.test.ts test/main/model/core-agent/tool-catalog.test.ts`
- `npm run test:js -- test/main/model/core-agent/tool-behavior-coverage.test.ts`
- `npm run typecheck`
- `ORKAS_WORKSPACE_ROOT=<temporary directory> npm run smoke`