### PR TITLE
fix(library): accept IPC status snapshots

### DIFF
--- a/src/renderer/modules/contexts.js
+++ b/src/renderer/modules/contexts.js
@@ -71,7 +71,7 @@ function _buildKbStatusMap(tree, statusRows) {
 }
 
 function _applyKbStatusResult(data) {
-  if (data && data.ok) {
+  if (data && data.ok !== false && Array.isArray(data.files)) {
     _kbUnavailableCode = '';
     _kbUnavailableReportedCode = '';
     return true;

--- a/test/renderer/contexts-external-drop.test.ts
+++ b/test/renderer/contexts-external-drop.test.ts
@@ -102,6 +102,14 @@ function dropEvent(dataTransfer: any, closestEntry: any = null) {
 }
 
 describe('Library external file drag-and-drop', () => {
+  it('accepts the successful KB status snapshot returned by the IPC handler', () => {
+    const context = loadContextsScript();
+
+    expect(context._applyKbStatusResult({ summary: { ready: 0 }, files: [] })).toBe(true);
+    expect(context._kbUnavailableHtml()).toBe('');
+    expect(context.__monitorError).not.toHaveBeenCalled();
+  });
+
   it('keeps files usable and exposes storage-full recovery guidance when KB startup fails', () => {
     const context = loadContextsScript();
 


### PR DESCRIPTION
Summary

- Accept the successful Library status shape returned by the IPC handler: summary plus files, without requiring a synthetic ok field.
- Preserve explicit ok=false failure handling and require a files array before clearing the unavailable state.
- Add renderer regression coverage for the real successful snapshot contract.

Testing

- node scripts/run-tests.mjs run test/renderer/contexts-external-drop.test.ts (24 passed)
- npm run typecheck