### PR TITLE
fix(connectors): hash encrypted grant log fingerprints

### DIFF
--- a/src/main/features/connectors/registry.ts
+++ b/src/main/features/connectors/registry.ts
@@ -320,20 +320,22 @@ function _writeSync(uid: string, data: ConnectorsFile): void {
       _deleted_at: data._deleted_at || {},
     }, null, 2);
     fs.writeFileSync(file, body, { mode: 0o600 });
-    // Diagnostic verify: read back size + the secrets_enc fingerprints we just wrote so a
+    // Diagnostic verify: read back size + a fingerprint of the secrets_enc we just wrote so a
     // future "the RT we sent doesn't match server" failure can be traced against actual
-    // bytes on disk at write time. `secrets_enc` is the AES-GCM blob; comparing its first
-    // 16 chars across log entries reveals whether a subsequent write clobbered this one.
+    // bytes on disk at write time. `secrets_enc` is the AES-GCM blob; a hash of it is a
+    // stable clobber-detection key without putting connector-grant bytes in the log.
     try {
       const st = fs.statSync(file);
       const fingerprints: Record<string, string> = {};
       for (const [id, disk] of Object.entries(onDisk)) {
-        if (disk.secrets_enc) fingerprints[id] = disk.secrets_enc.slice(0, 16);
+        if (disk.secrets_enc) {
+          fingerprints[id] = crypto.createHash('sha256').update(disk.secrets_enc).digest('hex').slice(0, 8);
+        }
       }
       log.info('connectors.json write ok', {
         bytes: st.size,
         mtime_ms: st.mtimeMs,
-        secrets_enc_prefix: fingerprints,
+        secrets_enc_hash: fingerprints,
       });
       _cacheWrite(uid, file, st, data);
     } catch (verifyErr) {

--- a/test/main/features/connectors/registry.test.ts
+++ b/test/main/features/connectors/registry.test.ts
@@ -1,7 +1,19 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import * as crypto from 'node:crypto';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
+
+const loggerMocks = vi.hoisted(() => ({
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+}));
+
+vi.mock('../../../../src/main/logger', () => ({
+  createLogger: () => loggerMocks,
+}));
 
 let tmpDir: string;
 let prevWs: string | undefined;
@@ -35,6 +47,7 @@ beforeEach(() => {
   tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'orkas-connectors-registry-'));
   prevWs = process.env.ORKAS_WORKSPACE_ROOT;
   process.env.ORKAS_WORKSPACE_ROOT = tmpDir;
+  vi.clearAllMocks();
   vi.resetModules();
 });
 
@@ -45,6 +58,24 @@ afterEach(() => {
 });
 
 describe('features/connectors/registry', () => {
+  it('logs a stable hash without exposing encrypted connector grant bytes', async () => {
+    const uid = 'uid-log-fingerprint';
+    const file = path.join(tmpDir, uid, 'cloud', 'config', 'connectors.json');
+    const registry = await import('../../../../src/main/features/connectors/registry');
+
+    await registry.upsert(uid, sampleInstance('github'));
+
+    const persisted = JSON.parse(fs.readFileSync(file, 'utf8'));
+    const ciphertext = String(persisted.connections.github.secrets_enc);
+    const expectedHash = crypto.createHash('sha256').update(ciphertext).digest('hex').slice(0, 8);
+    const writeLog = loggerMocks.info.mock.calls.find(([message]) => message === 'connectors.json write ok');
+    const fields = writeLog?.[1] as Record<string, unknown> | undefined;
+
+    expect(fields).toMatchObject({ secrets_enc_hash: { github: expectedHash } });
+    expect(fields).not.toHaveProperty('secrets_enc_prefix');
+    expect(JSON.stringify(fields)).not.toContain(ciphertext.slice(0, 16));
+  });
+
   it('writes a tombstone on remove and clears it when reconnecting the same id', async () => {
     const uid = 'uid-delete';
     const file = path.join(tmpDir, uid, 'cloud', 'config', 'connectors.json');


### PR DESCRIPTION
## Summary

- replace encrypted connector-grant prefixes in registry write logs with SHA-256 fingerprints
- preserve stable write-clobber diagnostics without exposing ciphertext bytes
- add regression coverage for the hash contract and absence of raw prefixes

## Verification

- `node scripts/run-tests.mjs run test/main/features/connectors/registry.test.ts test/main/features/connectors/manager.test.ts` (40 passed)
- `npm run typecheck`
- `npm run smoke`
- OSS safety scan: forbidden symbols/files, provider guard, orphan imports, UI, credit-connector, and package invariants all clean

This is a selective low-risk bugfix; it does not advance the release-wide synchronization baseline.