### PR TITLE
fix(core-agent): preserve recoverable tool stalls

### DIFF
--- a/src/main/model/core-agent/client.ts
+++ b/src/main/model/core-agent/client.ts
@@ -1480,12 +1480,25 @@ export async function* streamChatWithModel(opts: ChatOptions): AsyncGenerator<St
   };
   addActiveSessionAbort(userId, sessionId, activeAbortEntry);
 
+  // Keep the session-level tool tier strictly behind the per-tool watchdog
+  // for every configured idleTimeout; both derive from the same base value.
+  const TOOL_PHASE_BACKSTOP_RATIO = 1.15;
+  const toolIdleTimeoutMs = Math.max(1, Math.round(idleTimeout * 1000));
+  const toolPhaseBackstopMs = Math.max(
+    toolIdleTimeoutMs + 1,
+    Math.ceil(toolIdleTimeoutMs * TOOL_PHASE_BACKSTOP_RATIO),
+  );
   const resetIdle = () => {
     if (controller.signal.aborted) return;
     if (idleTimer) clearTimeout(idleTimer);
     const assemblingToolCall = assemblingToolCallIds.size > 0;
-    const inToolPhase = toolDepth > 0 || assemblingToolCall;
-    const window = !inToolPhase && modelTextStreamActive ? streamIdleTimeout : idleTimeout;
+    const toolExecuting = toolDepth > 0;
+    // Only an executing tool has a core-agent watchdog to own the base window;
+    // the host may then wait longer as a session backstop. Argument assembly
+    // happens before tool_start, so the host keeps the base idle deadline there.
+    const window = toolExecuting
+      ? toolPhaseBackstopMs / 1000
+      : (!assemblingToolCall && modelTextStreamActive ? streamIdleTimeout : idleTimeout);
     const phase: NonNullable<StreamEvent['failurePhase']> = toolDepth > 0
       ? 'tool'
       : (assemblingToolCall ? 'tool_input' : (modelTextStreamActive ? 'model_text' : 'provider_wait'));
@@ -1551,6 +1564,7 @@ export async function* streamChatWithModel(opts: ChatOptions): AsyncGenerator<St
       ...(resumeActiveTurn ? { resumeActiveTurn: true } : {}),
       ...(agentName ? { agentName } : {}),
       ...(maxToolLoops ? { maxToolLoops } : {}),
+      toolIdleTimeoutMs,
       ...(elapsedConvergenceMs != null ? { elapsedConvergenceMs } : {}),
       providerFirstEventTimeoutMs: Math.max(1, streamIdleTimeout * 1000),
       ...(cid ? { cid } : {}),

--- a/src/main/model/core-agent/runner.ts
+++ b/src/main/model/core-agent/runner.ts
@@ -236,6 +236,9 @@ export interface BuildRunnerParams {
   /** Max tool-call rounds per turn before force-end. Undefined → core-agent
    *  default (100). Group chat raises it for the commander's long builds. */
   maxToolLoops?: number;
+  /** Per-tool stall watchdog. The host derives this from the session idle
+   * timeout so the session-level tool-phase timer remains a later backstop. */
+  toolIdleTimeoutMs?: number;
   /** Optional one-time soft convergence threshold. Undefined preserves the
    *  core-agent default; this does not change the hard tool-loop limit. */
   elapsedConvergenceMs?: number;
@@ -1248,6 +1251,7 @@ export async function buildRunner(params: BuildRunnerParams): Promise<{
       defaultModel: modelId,
       ...(resolvedSystemPrompt ? { systemPrompt: resolvedSystemPrompt } : {}),
       ...(params.maxToolLoops ? { maxToolLoops: params.maxToolLoops } : {}),
+      ...(params.toolIdleTimeoutMs ? { toolIdleTimeoutMs: params.toolIdleTimeoutMs } : {}),
     },
     evolution: evolutionConfig,
     ...(Object.keys(modelCatalog).length ? { models: { catalog: modelCatalog } } : {}),

--- a/test/main/model/core-agent/client-stall.test.ts
+++ b/test/main/model/core-agent/client-stall.test.ts
@@ -178,6 +178,51 @@ describe('streamChatWithModel — phase-aware idle watchdog (Phase 1)', () => {
     expect(ms).toBeGreaterThanOrEqual(550);
   }, 8000);
 
+  it('tool-phase backstop stays behind the recoverable per-tool watchdog it configures', async () => {
+    // Production regression: both watchdogs shared the same 1800s deadline, so
+    // the session timer won and killed the whole turn instead of letting the
+    // per-tool watchdog return one recoverable tool error. The host must pass
+    // the base timeout to the runtime and keep its own backstop strictly later.
+    h.makeStream = () =>
+      (async function* () {
+        yield { type: 'tool_start', id: 't1', name: 'video_studio', input: {} };
+        await new Promise(() => {}); // tool never returns and never heartbeats
+      })();
+
+    const { events, ms } = await drain({ streamIdleTimeout: 0.2, idleTimeout: 2 });
+    expect(h.lastBuildRunnerParams?.toolIdleTimeoutMs).toBe(2000);
+    const failure = events.find((event) => event.type === 'error');
+    expect(failure).toMatchObject({
+      failureCode: 'idle_timeout',
+      failurePhase: 'tool',
+    });
+    // The mocked runner cannot emit its own tool-stall result, so the host
+    // fallback fires at 2.3s (2s x 1.15), not at the shared 2s deadline.
+    expect(failure?.text || '').toContain('2.3');
+    expect(ms).toBeGreaterThanOrEqual(2200);
+    expect(events.map((event) => event.type).at(-1)).toBe('done');
+  }, 10000);
+
+  it('keeps the tool-phase backstop strictly later at a sub-centisecond boundary', async () => {
+    h.makeStream = () =>
+      (async function* () {
+        yield { type: 'tool_start', id: 't1', name: 'video_studio', input: {} };
+        await new Promise(() => {});
+      })();
+
+    const { events } = await drain({ streamIdleTimeout: 0.001, idleTimeout: 0.01 });
+    expect(h.lastBuildRunnerParams?.toolIdleTimeoutMs).toBe(10);
+    const failure = events.find((event) => event.type === 'error');
+    expect(failure).toMatchObject({
+      failureCode: 'idle_timeout',
+      failurePhase: 'tool',
+    });
+    // A 10 ms runtime watchdog gets a 12 ms host backstop. The previous
+    // centisecond rounding collapsed both deadlines to the same 10 ms value.
+    expect(failure?.text || '').toContain('0.012');
+    expect(events.map((event) => event.type).at(-1)).toBe('done');
+  });
+
   it('post-tool model thinking is NOT false-killed by the short window', async () => {
     // Once a tool finishes, the next provider call can legitimately spend a
     // while thinking before the first text token. That post-tool cold-start
@@ -227,6 +272,25 @@ describe('streamChatWithModel — phase-aware idle watchdog (Phase 1)', () => {
     expect(types[types.length - 1]).toBe('done');
     expect(ms).toBeGreaterThanOrEqual(550);
   }, 8000);
+
+  it('keeps the base idle deadline while tool-call arguments are still assembling', async () => {
+    h.makeStream = () =>
+      (async function* () {
+        yield { type: 'tool_delta', id: 't1', name: 'write_file', inputDelta: '{', inputBytes: 1 };
+        await new Promise(() => {});
+      })();
+
+    const { events } = await drain({ streamIdleTimeout: 0.01, idleTimeout: 0.1 });
+    const failure = events.find((event) => event.type === 'error');
+    expect(failure).toMatchObject({
+      failureCode: 'idle_timeout',
+      failurePhase: 'tool_input',
+    });
+    // Core-agent cannot start a per-tool watchdog until complete arguments
+    // produce tool_start, so the host still owns the original 100 ms deadline.
+    expect(failure?.text || '').toContain('0.1s');
+    expect(events.map((event) => event.type).at(-1)).toBe('done');
+  });
 
   it('a fully silent (cold-start) stall still terminates cleanly — no wedge', async () => {
     // Regression guard for the main-side wedge: even with ZERO events the turn


### PR DESCRIPTION
## Summary

- keep the per-tool stall watchdog strictly ahead of the session-level backstop
- retain the original session timeout while streamed tool-call arguments are still assembling
- cover normal and sub-centisecond timeout boundaries

## Testing

- focused client-stall suite: 13 passed
- JavaScript suite: 507 files passed; 7,382 passed and 15 skipped
- resource suite: 345 passed
- TypeScript and E2E type checks passed
- Electron E2E: 130 passed
- platform-native: 33 files passed; 899 passed and 12 skipped
- smoke checks passed

## Sync boundary

This PR contains no Orkas account, cloud-sync, telemetry, managed-provider, Server, updater, release-pipeline, billing, or private-resource code.