### PR TITLE
fix(chat): render linked images inline

### DIFF
--- a/src/renderer/modules/utils.js
+++ b/src/renderer/modules/utils.js
@@ -1137,15 +1137,19 @@ function _dbXyChart(kind, data) {
   </div>`;
 }
 
-// Detect playable media src by extension. Dispatches markdown ![](src) /
-// [text](src) to a native player for video/audio instead of a generic link
-// — covers chat-media://local/...mp4, https://..../clip.webm, local .mp3
+// Detect renderable media src by extension. Dispatches markdown ![](src) /
+// [text](src) to an inline image or native player instead of a generic link
+// — covers chat-media://local/...png, https://..../clip.webm, local .mp3
 // outputs, and user-authored markdown pointing at a media file. The match is
 // against the last extension-looking segment so query strings / fragments
 // don't defeat it.
+const _IMAGE_EXT_RE = /\.(png|jpe?g|webp|gif|svg)(?:[?#].*)?$/i;
 const _VIDEO_EXT_RE = /\.(mp4|webm|mov|m4v|ogv)(?:[?#].*)?$/i;
 const _AUDIO_EXT_RE = /\.(mp3|wav|ogg|opus|m4a|aac|flac)(?:[?#].*)?$/i;
 const _HTML_EXT_RE = /\.html?$/i;
+function _isImageSrc(src) {
+  return _IMAGE_EXT_RE.test(String(src || ''));
+}
 function _isVideoSrc(src) {
   return _VIDEO_EXT_RE.test(String(src || ''));
 }
@@ -1700,9 +1704,10 @@ function inlineFormat(text) {
       (_, txt, rawUrl, title) => {
         // Media links get the same rewrite as `![](…)`: an agent delivering a
         // finished file writes `[视频成片](<path>)` as often as an embed.
-        const url = _isVideoSrc(rawUrl) || _isAudioSrc(rawUrl)
+        const url = _isImageSrc(rawUrl) || _isVideoSrc(rawUrl) || _isAudioSrc(rawUrl)
           ? _normalizeLocalMediaSrc(rawUrl)
           : rawUrl;
+        if (_isImageSrc(url)) return _markdownImageHtml(url, txt, title);
         if (_isVideoSrc(url)) return _markdownVideoHtml(url, txt, title);
         if (_isAudioSrc(url)) return _markdownAudioHtml(url, txt, title);
         // href: scheme-checked + escaped (blocks javascript:/data: and quote
@@ -2200,6 +2205,7 @@ if (typeof module !== 'undefined' && typeof module.exports === 'object') {
     _markdownVideoHtml,
     _markdownAudioHtml,
     _markdownHtmlEmbedHtml,
+    _isImageSrc,
     _isHtmlSrc,
     _markdownHtmlLayoutDimensions,
     _chatImageIntrinsicStyle,

--- a/test/renderer/utils-autolink.test.ts
+++ b/test/renderer/utils-autolink.test.ts
@@ -27,6 +27,7 @@ const {
   _markdownVideoHtml,
   _markdownAudioHtml,
   _markdownHtmlEmbedHtml,
+  _isImageSrc,
   _isHtmlSrc,
   _chatMediaLocalPathFromUrl,
   _normalizeLocalMediaSrc,
@@ -39,6 +40,7 @@ const {
   _markdownVideoHtml: (src: string, label: string, title?: string) => string;
   _markdownAudioHtml: (src: string, label: string, title?: string) => string;
   _markdownHtmlEmbedHtml: (src: string, label: string, title?: string) => string;
+  _isImageSrc: (src: string) => boolean;
   _isHtmlSrc: (src: string) => boolean;
   _chatMediaLocalPathFromUrl: (src: string) => string;
   _normalizeLocalMediaSrc: (src: string) => string;
@@ -173,6 +175,34 @@ describe('markdown media links', () => {
     expect(out).toContain('src="https://x.test/a.png?x=&quot;y&quot;"');
     expect(out).toContain('alt="&lt;car&gt;"');
     expect(out).toContain('title="&quot;preview&quot;"');
+  });
+
+  it('renders a normal Markdown link to a versioned local image inline', () => {
+    const src = 'chat-media://local/Users/test/.codex/generated_images/session/result.png?v=1-2-3';
+    const out = inlineFormat(`[查看并下载图片](${src})`);
+    expect(_isImageSrc(src)).toBe(true);
+    expect(out).toContain('<span class="chat-image-shell chat-md-img-shell is-loading">');
+    expect(out).toContain('<img class="chat-md-img"');
+    expect(out).toContain(`src="${src}"`);
+    expect(out).toContain('alt="查看并下载图片"');
+    expect(out).not.toContain('<a ');
+  });
+
+  it.each([
+    '/Users/test/.codex/generated_images/session/result.png',
+    'file:///Users/test/.codex/generated_images/session/result.webp',
+    'sandbox:/Users/test/.codex/generated_images/session/result.jpg',
+  ])('renders a normal Markdown link to local image alias %s inline', (src) => {
+    const out = inlineFormat(`[下载生成的图片](${src})`);
+    expect(out).toContain('<img class="chat-md-img"');
+    expect(out).toContain('src="chat-media://local/Users/test/.codex/generated_images/session/result.');
+    expect(out).not.toContain('<a ');
+  });
+
+  it('keeps a normal non-image Markdown link as an anchor', () => {
+    const out = inlineFormat('[下载文件](https://example.test/result.zip)');
+    expect(out).toContain('<a href="https://example.test/result.zip"');
+    expect(out).not.toContain('<img ');
   });
 
   it.each([


### PR DESCRIPTION
## Summary
- Render normal Markdown links to image files inline.
- Normalize local image path aliases before rendering.
- Preserve ordinary non-image links as anchors.

## Testing
- npm run typecheck
- npm run test:js (507 files, 7387 passed, 15 skipped)
- npm run test:resources (345 passed)
- npm run test:e2e:typecheck
- npm run test:e2e (130 passed)
- npm run test:platform-native (899 passed, 12 skipped)
- npm run smoke

## Open-source boundary
- Forbidden symbols/files, provider/API changes, orphan imports, OSS UI, credit-gated connectors, and package invariants: 0 findings.
- The repository-wide sync gate still reports pre-existing baseline drift in builtin resource parity and historical incremental coverage; this PR changes only the two files listed above.