### PR TITLE
fix(logging): redact structured error paths safely

### DIFF
--- a/src/main/util/log-redact.ts
+++ b/src/main/util/log-redact.ts
@@ -1,6 +1,8 @@
 import * as crypto from 'crypto';
 import * as path from 'path';
 
+import { sanitizeLogTextForUpload } from './log-sanitize';
+
 const MAX_LOG_MESSAGE_LEN = 240;
 
 export function maskId(value: unknown): string {
@@ -59,7 +61,9 @@ export function logRenameRef(from: unknown, to: unknown): Record<string, unknown
 }
 
 export function sanitizeLogText(value: unknown): string {
-  let text = String(value ?? '');
+  // Keep this helper safe when it is used before the central logger hook is
+  // initialized (for example in focused tests and startup error paths).
+  let text = sanitizeLogTextForUpload(String(value ?? ''));
   text = text.replace(/cloud\/[^\s'",)]+/g, (m) => `<cloud-path:${hashForLog(m)}>`);
   text = text.replace(/\/sync\/[A-Za-z0-9_/-]+/g, (m) => m.split('?')[0]);
   text = text.replace(/https?:\/\/[^\s'",)]+/g, (m) => safeUrlAction(m));

--- a/src/main/util/log-redact.ts
+++ b/src/main/util/log-redact.ts
@@ -61,13 +61,17 @@ export function logRenameRef(from: unknown, to: unknown): Record<string, unknown
 }
 
 export function sanitizeLogText(value: unknown): string {
-  // Keep this helper safe when it is used before the central logger hook is
-  // initialized (for example in focused tests and startup error paths).
-  let text = sanitizeLogTextForUpload(String(value ?? ''));
+  let text = String(value ?? '');
+  // Normalize sync-specific paths first. The central cloud-path matcher is
+  // intentionally sentence-aware and can otherwise absorb a following
+  // `via <url>` diagnostic into the path hash.
   text = text.replace(/cloud\/[^\s'",)]+/g, (m) => `<cloud-path:${hashForLog(m)}>`);
   text = text.replace(/\/sync\/[A-Za-z0-9_/-]+/g, (m) => m.split('?')[0]);
   text = text.replace(/https?:\/\/[^\s'",)]+/g, (m) => safeUrlAction(m));
   text = text.replace(/\b(ORKLSEC1|ghp|github_pat|sk|sk-proj|xox[baprs])[-_][-_A-Za-z0-9+/=:.]{12,}\b/g, '***REDACTED***');
+  // Keep this helper safe when it is used before the central logger hook is
+  // initialized (for example in focused tests and startup error paths).
+  text = sanitizeLogTextForUpload(text);
   if (text.length > MAX_LOG_MESSAGE_LEN) text = `${text.slice(0, MAX_LOG_MESSAGE_LEN)}...`;
   return text;
 }

--- a/test/main/util/log-redact.test.ts
+++ b/test/main/util/log-redact.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from 'vitest';
 import { redactPaths } from '../../../src/main/util/redact';
-import { logErrorRef, logErrorSummary, maskId, safeUrlAction } from '../../../src/main/util/log-redact';
+import {
+  logErrorRef,
+  logErrorSummary,
+  maskId,
+  safeUrlAction,
+  sanitizeLogText,
+} from '../../../src/main/util/log-redact';
 
 describe('log-redact', () => {
   it('masks opaque account and local ids while preserving anonymous', () => {
@@ -41,6 +47,19 @@ describe('log-redact', () => {
     expect(serialized).not.toContain('/Users/test');
     expect(serialized).not.toContain('Private Clips');
     expect(serialized).not.toContain('not-a-directory');
+  });
+
+  it('preserves safe URLs adjacent to cloud paths while redacting secrets', () => {
+    const text = sanitizeLogText(
+      'failed cloud/agents/abc123/skills/private/SKILL.md via https://example.com/sync/sts?token=secret ghp_abcdefghijklmnopqrstuvwxyz',
+    );
+
+    expect(text).toContain('<cloud-path:');
+    expect(text).toContain('https://example.com/sync/sts');
+    expect(text).toContain('***REDACTED***');
+    expect(text).not.toContain('private/SKILL.md');
+    expect(text).not.toContain('token=secret');
+    expect(text).not.toContain('ghp_abcdefghijklmnopqrstuvwxyz');
   });
 
   it('redacts local paths in subprocess stderr tails', () => {

--- a/test/main/util/log-redact.test.ts
+++ b/test/main/util/log-redact.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { redactPaths } from '../../../src/main/util/redact';
-import { logErrorSummary, maskId, safeUrlAction } from '../../../src/main/util/log-redact';
+import { logErrorRef, logErrorSummary, maskId, safeUrlAction } from '../../../src/main/util/log-redact';
 
 describe('log-redact', () => {
   it('masks opaque account and local ids while preserving anonymous', () => {
@@ -29,6 +29,18 @@ describe('log-redact', () => {
     expect(summary).toHaveProperty('message_hash');
     expect(JSON.stringify(summary)).not.toContain('private prompt fragment');
     expect(JSON.stringify(summary)).not.toContain('sk-secret1234567890');
+  });
+
+  it('redacts private absolute paths in structured error references', () => {
+    const ref = logErrorRef(
+      new Error("EEXIST: file already exists, mkdir '/Users/test/Private Clips/not-a-directory'"),
+    );
+    const serialized = JSON.stringify(ref);
+
+    expect(serialized).toContain('<abs-path:');
+    expect(serialized).not.toContain('/Users/test');
+    expect(serialized).not.toContain('Private Clips');
+    expect(serialized).not.toContain('not-a-directory');
   });
 
   it('redacts local paths in subprocess stderr tails', () => {


### PR DESCRIPTION
## Summary

- sanitize structured error messages before startup and focused logging can persist them
- preserve safe URL diagnostics beside redacted cloud paths while masking query tokens and credentials
- add regression coverage for both leak shapes

## Validation

- `npm run typecheck`
- `npm run test:e2e:typecheck`
- focused log redaction/sanitization tests: 34 passed
- JavaScript/TypeScript suite: 507 files, 7,389 passed, 15 skipped
- resource suite: 345 passed
- Electron E2E: 130 passed
- platform-native: 899 passed, 12 skipped
- `npm run smoke`

## Sync gate note

The targeted postcheck reports zero forbidden-symbol, forbidden-file, provider-guard, orphan-import, connector, package, TypeScript, or Renderer Node findings for this change. The repository-wide postcheck remains blocked by pre-existing `origin/main` baseline findings in recycle UI invariants, builtin hash drift, stale incremental exclusions, and Renderer symbol completeness; neither modified file is involved.
