### PR TITLE
fix: restore sidebar section toggles

### DIFF
--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -1691,6 +1691,7 @@
     };
   </script>
   <script src="./modules/math.js"></script>
+  <script src="./modules/sidebar-sections.js"></script>
   <script src="./modules/sidebar-resize.js"></script>
 </body>
 </html>

--- a/test/e2e/sidebar_e2e_sections.spec.ts
+++ b/test/e2e/sidebar_e2e_sections.spec.ts
@@ -1,0 +1,26 @@
+import { expect, test } from './fixtures/orkas';
+
+test.describe('sidebar sections', () => {
+  test('collapses and expands Projects and Tasks from their title controls', async ({ orkas }) => {
+    if (!orkas.page) throw new Error('Orkas renderer is unavailable');
+    const page = orkas.page;
+    const projectsToggle = page.locator('#projects-section-toggle');
+    const tasksToggle = page.locator('#tasks-section-toggle');
+
+    await expect(projectsToggle).toHaveAttribute('aria-expanded', 'true');
+    await expect(tasksToggle).toHaveAttribute('aria-expanded', 'true');
+
+    await projectsToggle.locator('.sidebar-section-title').click();
+    await expect(projectsToggle).toHaveAttribute('aria-expanded', 'false');
+    await expect(page.locator('#projects-list')).toBeHidden();
+
+    await tasksToggle.locator('.sidebar-section-title').click();
+    await expect(tasksToggle).toHaveAttribute('aria-expanded', 'false');
+    await expect(page.locator('#conversation-list')).toBeHidden();
+
+    await projectsToggle.locator('.sidebar-section-title').click();
+    await tasksToggle.locator('.sidebar-section-title').click();
+    await expect(projectsToggle).toHaveAttribute('aria-expanded', 'true');
+    await expect(tasksToggle).toHaveAttribute('aria-expanded', 'true');
+  });
+});


### PR DESCRIPTION
## Summary
- load the existing sidebar section controller in the open-source renderer
- cover Projects and Tasks collapse/expand with an Electron E2E regression

## Tests
- node scripts/run-tests.mjs run test/renderer/sidebar-sections.test.ts
- npx playwright test --config playwright.config.ts test/e2e/sidebar_e2e_sections.spec.ts
- npm run test:e2e:typecheck