### PR TITLE
Fix Codex startup and direct native test builds

### DIFF
--- a/scripts/build-notification-permission-addon.cjs
+++ b/scripts/build-notification-permission-addon.cjs
@@ -37,6 +37,10 @@ function removeDarwinOutputs(exceptArch = null, root = outputDir) {
  * binary, whose dist ships no headers. `npm_node_execpath` is the Node that
  * launched the npm script, which is where a nvm/fnm install keeps its headers
  * — without it, a machine with no Homebrew or system Node cannot build at all.
+ * `ORKAS_TEST_NODE` is the same outer Node, stamped by `scripts/run-tests.mjs`
+ * itself: it covers the runner being invoked directly (`node
+ * scripts/run-tests.mjs ...`), where npm sets no variables at all and the
+ * whole macOS suite would otherwise fail to build for the wrong reason.
  */
 function findNodeHeaders({
   env = process.env,
@@ -48,6 +52,7 @@ function findNodeHeaders({
     env.npm_config_nodedir && path.resolve(env.npm_config_nodedir, 'include', 'node'),
     includeDirOf(execPath),
     env.npm_node_execpath && includeDirOf(env.npm_node_execpath),
+    env.ORKAS_TEST_NODE && includeDirOf(env.ORKAS_TEST_NODE),
     '/opt/homebrew/include/node',
     '/usr/local/include/node',
     '/usr/include/node',

--- a/src/main/features/local_agents/backends/codex.ts
+++ b/src/main/features/local_agents/backends/codex.ts
@@ -1102,21 +1102,16 @@ export function buildCodexTurnRuntimeOverrides(
   };
 }
 
-export const CODEX_OPENAI_HTTP_TRANSPORT_OVERRIDE =
-  'model_providers.openai.supports_websockets=false';
-
 export function buildCodexArgs(opts: BackendRunOptions): string[] {
   // Per multica: `codex app-server --listen stdio://` is the entry
   // point for the JSON-RPC protocol. customArgs trail.
-  // Keep the provider stream on HTTPS/SSE. A Responses WebSocket can remain
-  // half-open after an output-item start: Codex then emits neither app-server
-  // progress nor a transport failure, so its built-in HTTPS fallback never
-  // runs. SSE retains Codex's own idle detection/retry without imposing an
-  // Orkas-side deadline or cancelling a turn that may still recover.
-  const args = [
-    'app-server', '--listen', 'stdio://',
-    '-c', CODEX_OPENAI_HTTP_TRANSPORT_OVERRIDE,
-  ];
+  // Keep Codex's built-in OpenAI provider intact. Current Codex versions
+  // reserve that provider id and reject `model_providers.openai.*` overrides
+  // before JSON-RPC initialization; ChatGPT login also relies on the built-in
+  // provider owning its WebSocket-to-HTTPS fallback. Orkas observes Codex
+  // retry events and applies its process watchdog, but does not select the
+  // provider transport itself.
+  const args = ['app-server', '--listen', 'stdio://'];
   // orkas-bridge: codex takes config-layer overrides (`-c key=value`,
   // TOML-parsed) instead of a config file. Codex spawns stdio MCP servers
   // with a sanitized env (PATH/HOME only) — it does NOT inherit this Codex

--- a/test/main/features/local_agents/bridge_args.test.ts
+++ b/test/main/features/local_agents/bridge_args.test.ts
@@ -4,7 +4,6 @@ import { buildClaudeArgs } from '../../../../src/main/features/local_agents/back
 import {
   buildCodexArgs,
   buildCodexBridgeOverrides,
-  CODEX_OPENAI_HTTP_TRANSPORT_OVERRIDE,
   codexDeveloperInstructions,
   codexThreadDeveloperInstructionParams,
 } from '../../../../src/main/features/local_agents/backends/codex';
@@ -64,19 +63,16 @@ describe('claude bridge args', () => {
 });
 
 describe('codex bridge overrides', () => {
-  it('uses the recoverable HTTP response stream while leaving user overrides last', () => {
-    const userOverride = 'model_providers.openai.supports_websockets=true';
+  it('keeps the reserved OpenAI provider intact while leaving user overrides last', () => {
+    const userOverride = 'model="gpt-5.6-sol"';
     const args = buildCodexArgs({
       ...BASE,
       customArgs: ['-c', userOverride],
     });
 
-    expect(args.slice(0, 5)).toEqual([
-      'app-server', '--listen', 'stdio://',
-      '-c', CODEX_OPENAI_HTTP_TRANSPORT_OVERRIDE,
-    ]);
-    expect(args.lastIndexOf(userOverride))
-      .toBeGreaterThan(args.indexOf(CODEX_OPENAI_HTTP_TRANSPORT_OVERRIDE));
+    expect(args.slice(0, 3)).toEqual(['app-server', '--listen', 'stdio://']);
+    expect(args.filter(arg => arg.startsWith('model_providers.openai'))).toEqual([]);
+    expect(args.slice(-2)).toEqual(['-c', userOverride]);
   });
 
   it('emits TOML-quoted -c overrides for command/args and non-secret env', () => {

--- a/test/main/util/build-notification-permission-addon.test.ts
+++ b/test/main/util/build-notification-permission-addon.test.ts
@@ -194,6 +194,16 @@ describe('notification permission native addon build', () => {
       exists: has(nodedirHeaders, nvmHeaders),
     })).toBe(nodedirHeaders);
 
+    // Invoking `scripts/run-tests.mjs` directly sets none of npm's variables,
+    // so the runner's own record of the outer Node has to carry the lookup —
+    // otherwise the macOS native suite fails on the harness rather than on the
+    // behavior it covers.
+    expect(addonBuilder.findNodeHeaders({
+      env: { ORKAS_TEST_NODE: nvmNode },
+      execPath: electron,
+      exists: has(nvmHeaders),
+    })).toBe(nvmHeaders);
+
     // Negative control: with nothing available it must fail loudly and name
     // the escape hatch, never hand the compiler a directory that is not there.
     expect(() => addonBuilder.findNodeHeaders({


### PR DESCRIPTION
## Summary

- keep Codex built-in OpenAI provider configuration intact so current Codex versions can initialize app-server successfully
- let direct test-runner invocations resolve Node headers through ORKAS_TEST_NODE when building the macOS notification-permission addon
- preserve the open-source test placeholders instead of copying a source-only developer home path

## Source

- Orkas 5c873c8b6: fix(codex): restore compatible app-server startup
- Orkas 222534794: fix(build): let the notification addon build find headers from a direct runner invoke

## Testing

- regression tests failed on both old behaviors before the implementation changes
- npm run test:js -- test/main/core-regression.test.ts test/main/features/local_agents/bridge_args.test.ts test/main/util/build-notification-permission-addon.test.ts (27/27)
- npm run typecheck
- Codex 0.147.0 probe: the removed provider override exits 1 before JSON-RPC initialization; the clean app-server invocation exits 0
- git diff --check