### PR TITLE
fix(core-agent): preserve parallel tool-result clusters

### DIFF
--- a/src/core-agent/src/agent/session.ts
+++ b/src/core-agent/src/agent/session.ts
@@ -1176,10 +1176,11 @@ export class Session {
 
       // Workspace state is persistent structured evidence. When its latest
       // file change has a visible causal tool result, place the net state
-      // immediately after that result so later read/command rounds can reuse it
-      // as prefix. If checkpointing hides the result, place it after the
-      // checkpoint; unattributed reconciliation remains conservatively at the
-      // tail. Visible command results are not repeated in this projection.
+      // immediately after that result's complete provider tool-result cluster
+      // so later read/command rounds can reuse it as prefix without splitting
+      // parallel tool responses. If checkpointing hides the result, place it
+      // after the checkpoint; unattributed reconciliation remains
+      // conservatively at the tail. Visible command results are not repeated.
       //
       // Completed work and the plan remain deterministic tail state.
       // Completed-work entries whose exact raw tool_result is still present in
@@ -1202,7 +1203,7 @@ export class Session {
             content: [{ type: "text", text: markPrivateRuntimeContext(workspace.text) }],
           };
           const anchoredIndex = workspace.anchorToolCallId
-            ? insertionIndexAfterToolResult(result, workspace.anchorToolCallId)
+            ? insertionIndexAfterToolResultCluster(result, workspace.anchorToolCallId)
             : undefined;
           const insertionIndex = anchoredIndex
             ?? (workspace.anchorToolCallId && checkpointContextIndex !== undefined
@@ -2891,7 +2892,7 @@ function visibleToolResultIds(messages: readonly Message[]): Set<string> {
   return ids;
 }
 
-function insertionIndexAfterToolResult(
+function insertionIndexAfterToolResultCluster(
   messages: readonly Message[],
   toolCallId: string,
 ): number | undefined {
@@ -2900,14 +2901,18 @@ function insertionIndexAfterToolResult(
   )));
   if (resultIndex < 0) return undefined;
   let insertionIndex = resultIndex + 1;
-  // Tool-result images are separate user messages by provider contract. Keep
-  // those trailers attached to the result rather than inserting runtime state
-  // between the text result and its image evidence.
+  // A single assistant message can declare several tool calls. Session stores
+  // each result (and any image trailer) as a separate user message, but the
+  // provider protocol treats the entire consecutive sequence as one atomic
+  // response cluster. Inserting host runtime context after only the anchored
+  // result would detach every later tool result from assistant.tool_calls.
   while (
     insertionIndex < messages.length
     && messages[insertionIndex].role === "user"
     && messages[insertionIndex].content.length > 0
-    && messages[insertionIndex].content.every((content) => content.type === "image")
+    && messages[insertionIndex].content.every((content) => (
+      content.type === "tool_result" || content.type === "image"
+    ))
   ) {
     insertionIndex++;
   }

--- a/src/core-agent/test/session.test.ts
+++ b/src/core-agent/test/session.test.ts
@@ -1908,6 +1908,58 @@ describe("Session execution plan anchor", () => {
     expect(session.estimateModelTokens()).toBe(tokensBeforeCommandObservation);
   });
 
+  it("keeps workspace state outside a parallel tool-result cluster", () => {
+    const session = new Session();
+    session.beginUserTurn([{ type: "text", text: "Write the manifest and render the image" }]);
+    session.addAssistantMessage([
+      {
+        type: "tool_use",
+        id: "write-manifest",
+        name: "write_file",
+        input: { path: "/workspace/manifest.json" },
+      },
+      {
+        type: "tool_use",
+        id: "render-image",
+        name: "image_studio",
+        input: { manifest: "/workspace/manifest.json" },
+      },
+    ]);
+    session.recordToolObservations({
+      toolCallId: "write-manifest",
+      tool: "write_file",
+      observations: {
+        fileChanges: [{
+          operation: "create",
+          sourcePath: "/workspace/manifest.json",
+          beforeExists: false,
+          afterExists: true,
+          afterHash: "sha256:manifest",
+          coverage: "exact",
+        }],
+      },
+    });
+    session.addToolResult("write-manifest", "MANIFEST_WRITTEN", undefined, false);
+    session.addToolResult("render-image", "E_MANIFEST_REFERENCE_ROLE", undefined, true);
+
+    const modelView = session.getMessagesForModel();
+    const indexOfContent = (predicate: (content: typeof modelView[number]["content"][number]) => boolean) => (
+      modelView.findIndex((message) => message.content.some(predicate))
+    );
+    const writeResultIndex = indexOfContent((content) => (
+      content.type === "tool_result" && content.toolUseId === "write-manifest"
+    ));
+    const renderResultIndex = indexOfContent((content) => (
+      content.type === "tool_result" && content.toolUseId === "render-image"
+    ));
+    const workspaceIndex = indexOfContent((content) => (
+      content.type === "text" && content.text.startsWith("[Workspace changes")
+    ));
+
+    expect(renderResultIndex).toBe(writeResultIndex + 1);
+    expect(workspaceIndex).toBe(renderResultIndex + 1);
+  });
+
   it("moves the workspace anchor only after the latest causal file change", () => {
     const session = new Session();
     session.beginUserTurn([{ type: "text", text: "Update both files in order" }]);


### PR DESCRIPTION
## Summary

- keep workspace runtime context outside contiguous parallel tool-result messages
- preserve image messages that belong to the same result cluster
- add a regression test for parallel tool-result ordering

## Verification

- `npm run test:js -- src/core-agent/test/session.test.ts` (88/88 passed)
- `npm run typecheck`
- `./node_modules/.bin/tsc --noEmit -p src/core-agent/tsconfig.json`