### PR TITLE
fix(video): preserve budget after full cache recovery

### DIFF
--- a/src/main/features/video_studio.ts
+++ b/src/main/features/video_studio.ts
@@ -4896,14 +4896,28 @@ async function buildMediaQa(
   };
 }
 
-/** Did a resumable segment-assembly failure cache at least one NEW segment?
- * Forward progress means an unchanged-input retry genuinely advances, so the
- * draft repair budget must not count it as a repeated failure; zero-progress
- * repetition still spends the budget and stays bounded. */
+/** Did a resumable segment-assembly failure preserve useful render progress?
+ * A newly rendered segment advances the retry. A complete cache hit also
+ * proves that content rendering already succeeded and the failure happened in
+ * a later assembly/environment stage. Both are budget-neutral; incomplete or
+ * contradictory counters stay bounded by the ordinary repair budget. */
 export function resumableRenderFailureMadeProgress(render: VideoStudioResult): boolean {
   if (render.ok !== false || render.errorCode !== 'E_SEGMENT_ASSEMBLY_INCOMPLETE') return false;
-  const rendered = (render.scene_segments as { rendered?: unknown } | undefined)?.rendered;
-  return typeof rendered === 'number' && rendered > 0;
+  const segments = render.scene_segments as {
+    total?: unknown;
+    rendered?: unknown;
+    reused?: unknown;
+    failed?: unknown;
+    pending?: unknown;
+  } | undefined;
+  if (typeof segments?.rendered === 'number' && segments.rendered > 0) return true;
+  return typeof segments?.total === 'number'
+    && Number.isInteger(segments.total)
+    && segments.total > 0
+    && typeof segments.reused === 'number'
+    && segments.reused === segments.total
+    && segments.failed === 0
+    && segments.pending === 0;
 }
 
 async function failDraft(

--- a/test/main/features/video_studio_native_qa.test.ts
+++ b/test/main/features/video_studio_native_qa.test.ts
@@ -6066,7 +6066,7 @@ describe('P3c R2 scene segment assembly', () => {
     expect(new Set([key, ...variants]).size).toBe(variants.length + 1);
   });
 
-  it('spends the draft repair budget only on zero-progress resumable failures', () => {
+  it('spends the draft repair budget only when resumable evidence shows no content progress', () => {
     // A resume that cached at least one NEW segment genuinely advanced, so it
     // must not burn a content-repair pass; a zero-progress repeat must, or
     // unchanged-input repetition would be unbounded.
@@ -6079,6 +6079,30 @@ describe('P3c R2 scene segment assembly', () => {
     } as Parameters<typeof resumableRenderFailureMadeProgress>[0]);
     expect(resumableRenderFailureMadeProgress(incomplete(2))).toBe(true);
     expect(resumableRenderFailureMadeProgress(incomplete(0))).toBe(false);
+    // A complete cache hit means all content segments already rendered. A
+    // later concat/remux/probe failure is environmental and budget-neutral.
+    expect(resumableRenderFailureMadeProgress({
+      ok: false,
+      op: 'composition.render',
+      errorCode: 'E_SEGMENT_ASSEMBLY_INCOMPLETE',
+      message: 'concat failed',
+      scene_segments: { total: 3, rendered: 0, reused: 3, failed: 0, pending: 0, resumable: true },
+    } as Parameters<typeof resumableRenderFailureMadeProgress>[0])).toBe(true);
+    // Near-misses remain bounded: partial reuse, contradictory counters, and
+    // missing post-render counters cannot claim a completed content render.
+    for (const scene_segments of [
+      { total: 3, rendered: 0, reused: 2, failed: 0, pending: 1, resumable: true },
+      { total: 3, rendered: 0, reused: 3, failed: 1, pending: 0, resumable: true },
+      { total: 3, rendered: 0, reused: 3, resumable: true },
+    ]) {
+      expect(resumableRenderFailureMadeProgress({
+        ok: false,
+        op: 'composition.render',
+        errorCode: 'E_SEGMENT_ASSEMBLY_INCOMPLETE',
+        message: 'incomplete',
+        scene_segments,
+      } as Parameters<typeof resumableRenderFailureMadeProgress>[0])).toBe(false);
+    }
     // Other render failures never skip the budget, whatever counters they carry.
     expect(resumableRenderFailureMadeProgress({
       ok: false,


### PR DESCRIPTION
## Summary

- treat a fully recovered scene-segment cache as real render progress when failure occurs later in concat, remux, or probe work
- keep partial, contradictory, and non-resumable failures bounded by the existing draft repair budget
- add focused regression coverage for the complete-cache and near-miss shapes

## Source

- Orkas `eb951ba433ba65ad6e1534298b9adf513a0dcbfa`
- only provider-neutral VideoStudio code and its existing deterministic test are synchronized; account, telemetry, managed-provider, updater, relay, and internal development modules remain excluded

## Verification

- negative control: the focused regression failed against the old implementation
- `npm run test:js -- test/main/features/video_studio_native_qa.test.ts -t "spends the draft repair budget only when resumable evidence shows no content progress"` (1 passed)
- `npm run test:js -- test/main/features/video_studio_native_qa.test.ts` (177 passed, 2 skipped)
- `npm run typecheck`
- `git diff --check`
- synchronized patch content matches the source commit exactly, apart from target line numbers
- OSS postcheck reports zero forbidden-symbol, forbidden-file, provider/API, orphan-import, UI, credit-connector, package, TypeScript, and renderer violations; its two full-inventory failures reproduce unchanged on clean `origin/main` (existing target-owned resource hash drift and incomplete incremental sync ledger)