### PR TITLE
fix(indexing): redact materialisation log identifiers

### DIFF
--- a/src/main/features/file_indexer.ts
+++ b/src/main/features/file_indexer.ts
@@ -43,6 +43,7 @@ import { finished } from 'node:stream/promises';
 import { userChatAttachmentsDir, userFileCacheDir, projectChatAttachmentsDir } from '../paths';
 import { listProjectIds } from '../util/project-layout';
 import { createLogger } from '../logger';
+import { logPathRef, maskId } from '../util/log-redact';
 import { macosTccSensitivePath } from '../util/macos-tcc';
 import { pdfBufferToPages, EXTRACT_CACHE_VERSION } from '../util/extract-pdf';
 import { docxBufferToMarkdown } from '../util/extract-docx';
@@ -545,12 +546,15 @@ async function materialise(
   // image: no cache payload at all.
 
   writeMeta(dir, base);
-  log.info(
-    `materialise user=${userId} kind=${kind} chars=${base.totalChars ?? 0}`
-    + (kind === 'pdf' ? ` pages=${base.pageMap?.length ?? 0}` : '')
-    + (base.extractionEmpty ? ' extraction=empty_pages' : '')
-    + ` ms=${Date.now() - t0} path=${absPath}`,
-  );
+  log.info('materialise', {
+    user_id: maskId(userId),
+    kind,
+    chars: base.totalChars ?? 0,
+    ...(kind === 'pdf' ? { pages: base.pageMap?.length ?? 0 } : {}),
+    ...(base.extractionEmpty ? { extraction: 'empty_pages' } : {}),
+    duration_ms: Date.now() - t0,
+    path: logPathRef(absPath),
+  });
   return base;
 }
 

--- a/test/main/features/file_indexer.test.ts
+++ b/test/main/features/file_indexer.test.ts
@@ -8,6 +8,16 @@ import * as path from 'node:path';
 import { makeMinimalPdf } from '../../fixtures/make-minimal-pdf';
 import { makeMinimalDocx } from '../../fixtures/make-minimal-docx';
 
+const loggerMocks = vi.hoisted(() => ({ info: vi.fn() }));
+vi.mock('../../../src/main/logger', () => ({
+  createLogger: () => ({
+    debug: vi.fn(),
+    info: loggerMocks.info,
+    warn: vi.fn(),
+    error: vi.fn(),
+  }),
+}));
+
 const UID = 'u-fi-001';
 
 let tmpDir: string;
@@ -65,6 +75,25 @@ async function makePng(): Promise<Buffer> {
 }
 
 describe('file_indexer › statFile', () => {
+  it('logs only masked account and path references when materialising', async () => {
+    const m = await loadMod();
+    loggerMocks.info.mockClear();
+    const abs = writeWorkspaceFile('private-customer-filename.md', 'private body');
+    await m.statFile(UID, abs);
+
+    expect(loggerMocks.info).toHaveBeenCalledWith('materialise', expect.objectContaining({
+      user_id: 'u-***01',
+      kind: 'text',
+      chars: 12,
+      path: expect.objectContaining({ domain: 'absolute', ext: '.md' }),
+    }));
+    const serialized = JSON.stringify(loggerMocks.info.mock.calls);
+    expect(serialized).not.toContain(UID);
+    expect(serialized).not.toContain(tmpDir);
+    expect(serialized).not.toContain('private-customer-filename.md');
+    expect(serialized).not.toContain('private body');
+  });
+
   it('returns totalChars for text', async () => {
     const m = await loadMod();
     const body = 'line one\nline two\nline three';


### PR DESCRIPTION
## Summary

- replace the file materialisation log string with structured diagnostics
- mask the local user id and reduce the absolute file path to a non-reversible path reference
- retain useful kind, character count, page count, extraction state, and duration fields

## Source

- Orkas `ff38870561d3b0cd0711b56987d1103e0659240e`
- only the shared file indexer and its deterministic regression are synchronized; Server, Web, iOS, account, telemetry, hosted-provider, updater, relay, release, and internal-development modules remain excluded
- both synchronized blobs and the stable patch-id match the source commit exactly

## Verification

- negative control: the focused regression failed against the old implementation and exposed the full local user id, temporary directory, and private filename in the captured logger arguments
- `npm run test:js -- test/main/features/file_indexer.test.ts` (28 passed)
- `npm run typecheck`
- `npm run smoke`
- `git diff --check`
- OSS boundary checks report zero forbidden-symbol, forbidden-file, provider/API, orphan-import, UI, credit-connector, package, TypeScript, renderer-syntax, and renderer-symbol violations
- the full OSS postcheck reproduces two unrelated repository-baseline failures: one target-owned builtin resource hash drift and stale private exclusion-review entries outside this single-commit source range