### PR TITLE
fix(cli): surface Codex stdin API key prompt

### DIFF
--- a/src/main/model/core-agent/interactive-cli-sessions.ts
+++ b/src/main/model/core-agent/interactive-cli-sessions.ts
@@ -184,6 +184,7 @@ function detectPrompt(text: string): { kind: InteractiveCliPromptKind; sensitive
   if (
     /\b(?:enter|paste|input|provide|type)\b.{0,60}\b(?:password|passcode|client\s+secret|secret|token|api\s*key|private\s+key)\b/i.test(tail)
     || /\b(?:password|passcode|client\s+secret|secret|token|api\s*key|private\s+key)\s*[:?]\s*$/i.test(tail)
+    || /\breading\b.{0,60}\b(?:password|passcode|client\s+secret|secret|token|api\s*key|private\s+key)\b.{0,30}\bfrom\s+stdin\b/i.test(tail)
   ) {
     return { kind: 'secret', sensitive: true };
   }

--- a/test/main/model/local-tools.test.ts
+++ b/test/main/model/local-tools.test.ts
@@ -942,6 +942,38 @@ describe('local-tools › interactive_cli lifecycle', () => {
     await interactive.execute({ action: 'close', session_id: started.session_id, force: true, reason: 'test cleanup' }, makeCtx());
   }, 10000);
 
+  it('hands the Codex stdin API-key prompt to the user', async () => {
+    const { lt, perm } = await loadModules();
+    perm.setLocalExecMode('all_files_auto');
+    const interactive = toolByName(
+      lt.createLocalTools({ userId: 'u1', cid: 'c1', agentId: 'a1' }),
+      'interactive_cli',
+    );
+    const command = testNodeCommand(
+      "process.stdout.write('Reading API key from stdin...'); setInterval(() => {}, 1000);",
+    );
+
+    const startResult = await interactive.execute({
+      action: 'start',
+      command,
+      max_lifetime_ms: 30000,
+    }, makeCtx());
+    const started = parseToolJson(startResult);
+
+    expect(started.output).toContain('Reading API key from stdin...');
+    expect(started.prompt_kind).toBe('secret');
+    expect(started.user_action_required).toBe(true);
+    expect(started.agent_should_stop).toBe(true);
+    expect(startResult.endTurn).toBe(true);
+
+    await interactive.execute({
+      action: 'close',
+      session_id: started.session_id,
+      force: true,
+      reason: 'test cleanup',
+    }, makeCtx());
+  }, 10000);
+
   it('keeps interactive CLI available in workspace_approval mode', async () => {
     const { lt, perm } = await loadModules();
     perm.setLocalExecMode('workspace_approval');


### PR DESCRIPTION
## Summary

- recognize Codex's `Reading API key from stdin...` output as a sensitive interactive prompt
- return control to the user instead of leaving the agent stalled on a live CLI session
- cover the full tool payload, including `prompt_kind`, `user_action_required`, and end-of-turn behavior

## Verification

- `npm run test:js -- test/main/model/local-tools.test.ts` — 124 passed
- `npm run typecheck` — passed
- OSS sync precheck — no strip targets
- OSS postcheck — this change adds no violations; the same 9 existing baseline violations reproduce on clean `origin/main`
