### PR TITLE
fix(prompts): redact template paths in loader logs

### DIFF
--- a/src/main/prompts/loader.ts
+++ b/src/main/prompts/loader.ts
@@ -19,6 +19,7 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { createLogger } from '../logger';
+import { logErrorSummary, logPathRef } from '../util/log-redact';
 import {
   safeSubstitute,
   type TemplateArgs,
@@ -49,13 +50,16 @@ export class PromptManager {
     const p = this._pathFor(template);
     let stat: fs.Stats;
     try { stat = fs.statSync(p); }
-    catch { log.warn(`template missing: ${p}`); return ''; }
+    catch { log.warn('prompt template missing', { path: logPathRef(p) }); return ''; }
     const mtime = stat.mtimeMs;
     const cached = this._cache.get(template);
     if (cached && cached.mtime === mtime) return cached.body;
     let body: string;
     try { body = fs.readFileSync(p, 'utf8'); }
-    catch (err) { log.warn(`failed to read ${p}: ${(err as Error).message}`); return ''; }
+    catch (err) {
+      log.warn('prompt template read failed', { path: logPathRef(p), error: logErrorSummary(err) });
+      return '';
+    }
     this._cache.set(template, { mtime, body });
     return body;
   }

--- a/test/main/prompts/loader.test.ts
+++ b/test/main/prompts/loader.test.ts
@@ -1,9 +1,15 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import { PromptManager, safeSubstitute, prompts } from '../../../src/main/prompts/loader';
 import { buildRuntimeDatetimeBlock, formatCurrentDate } from '../../../src/main/prompts/runtime_context';
+
+const loggerMocks = vi.hoisted(() => ({ warn: vi.fn() }));
+
+vi.mock('../../../src/main/logger', () => ({
+  createLogger: () => ({ debug: vi.fn(), info: vi.fn(), warn: loggerMocks.warn, error: vi.fn() }),
+}));
 
 describe('prompts › safeSubstitute', () => {
   it('substitutes $identifier', () => {
@@ -67,6 +73,7 @@ describe('prompts › PromptManager (custom root)', () => {
   let mgr: PromptManager;
 
   beforeEach(() => {
+    loggerMocks.warn.mockClear();
     tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'orkas-prompts-'));
     mgr = new PromptManager(tmpDir);
   });
@@ -88,6 +95,11 @@ describe('prompts › PromptManager (custom root)', () => {
 
   it('load() returns empty string for missing template', () => {
     expect(mgr.load('missing')).toBe('');
+    expect(loggerMocks.warn).toHaveBeenCalledWith(
+      'prompt template missing',
+      { path: expect.objectContaining({ path_hash: expect.any(String), domain: 'absolute' }) },
+    );
+    expect(JSON.stringify(loggerMocks.warn.mock.calls)).not.toContain(tmpDir);
   });
 
   it('caches body — when mtime is held constant, load returns cached body even after content rewrite', () => {


### PR DESCRIPTION
## Summary

- replace raw prompt-template filesystem paths with structured, non-reversible path references
- summarize template read failures without logging unrestricted error text
- preserve template lookup, substitution, caching, and empty fallback behavior
- add a deterministic regression for the missing-template privacy boundary

## Source and open-source boundary

- Orkas `f095d012ad772e725996f4fadafeed83836e6cf2`
- the synchronized stable patch-id is `a398dc1df70a7d50f23916c6ba252237fb38617b`
- OSS precheck classified both changed files as shared and found no strip targets
- account, cloud-sync, telemetry, hosted-provider, updater, relay, release, Server, Web, iOS, and internal-development modules remain excluded
- no system-prompt text, composition, placement, precedence, dependency, or product behavior changes

## Verification

- negative control: the new regression failed on clean `origin/main`, capturing the old raw temporary path in the logger call
- `npm run test:js -- test/main/prompts/loader.test.ts` — 37 passed
- `npm run typecheck` — passed
- `npm run smoke` — passed; the expected missing-template recovery warning contains only a structured path reference
- `git diff --check origin/main...HEAD` — passed
- OSS boundary checks report zero forbidden-symbol, forbidden-file, provider/API, orphan-import, UI, credit-connector, package, TypeScript, renderer-syntax, and renderer-symbol violations
- the full OSS postcheck reproduces the same two unrelated repository-baseline failures on clean `origin/main`: one target-owned builtin resource hash drift and three stale exclusion-review entries outside this single-commit source range