### PR TITLE
fix(local-agents): match only real stale-session errors

### DIFF
--- a/src/main/features/local_agents/context.ts
+++ b/src/main/features/local_agents/context.ts
@@ -44,10 +44,15 @@ export interface CliContextMaterialization {
   resumeFallbackPrompt: string;
 }
 
+// A rejected resume drops the native session binding and restarts the CLI
+// from bounded recovery, so a false match costs the user their working
+// context. Match only the CLI's own stale-session phrasings: the failure
+// word must sit next to the word "session" (optionally its id), not anywhere
+// on a line that merely mentions a session file, flag, or module.
 const CLI_RESUME_REJECTED_PATTERNS = [
   /No conversation found with session ID/i,
-  /session.*(not found|does not exist|expired|invalid|unknown)/i,
-  /(not found|does not exist|expired|invalid|unknown).*session/i,
+  /\bsession(?: id)?\b(?: [^\s]+)? (?:was |is |has )?(?:not found|does not exist|no longer exists|expired|invalid|unknown)\b/i,
+  /\b(?:unknown|invalid|expired|stale|no such|missing) session(?: id)?\b/i,
 ];
 
 export function isCliResumeRejectedMessage(value: unknown): boolean {

--- a/test/main/features/local_agents/context.test.ts
+++ b/test/main/features/local_agents/context.test.ts
@@ -186,6 +186,17 @@ describe('local_agents/context › semantic CLI context', () => {
     expect(isCliResumeRejectedMessage('No conversation found with session ID abc')).toBe(true);
     expect(isCliResumeRejectedMessage('session does not exist')).toBe(true);
     expect(isCliResumeRejectedMessage('unknown session abc')).toBe(true);
+    expect(isCliResumeRejectedMessage('Error: session abc123 not found')).toBe(true);
+    expect(isCliResumeRejectedMessage('session id 0f3a is invalid')).toBe(true);
+    expect(isCliResumeRejectedMessage('resume failed: no such session')).toBe(true);
     expect(isCliResumeRejectedMessage('tests failed in session-manager.ts')).toBe(false);
+    // Ordinary stderr from a healthy resumed session must not drop its binding:
+    // a compiler, linter, or the task's own output routinely pairs "session"
+    // with "unknown"/"invalid"/"not found" somewhere on the same line.
+    expect(isCliResumeRejectedMessage('src/session-manager.ts(12,3): error TS2339: unknown property')).toBe(false);
+    expect(isCliResumeRejectedMessage('invalid JSON in ~/.config/app/session.json')).toBe(false);
+    expect(isCliResumeRejectedMessage('Unknown flag --session-timeout')).toBe(false);
+    expect(isCliResumeRejectedMessage('404 not found: /api/sessions/list while session was active')).toBe(false);
+    expect(isCliResumeRejectedMessage('expired token; refreshing before the next session call')).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

- narrow resume-rejection detection to actual stale-session CLI phrasings
- preserve a healthy native session binding when ordinary stderr merely mentions session files, flags, modules, HTTP paths, or token refresh
- keep bounded fresh-session recovery for genuine missing, expired, invalid, or unknown sessions

## Source and open-source boundary

- Orkas `4eeef4d1c7823fc79025a8ef131ba4be69d0cf3e`
- synchronized stable patch-id: `9c4b75d6fc12d3cf7cf2cc0ca6963a38d0205037`
- source-parent and target-base SHA-256 values matched for both changed files; the resulting target files also match the source commit byte-for-byte
- OSS precheck scanned both changed shared files and found no strip targets
- account, cloud sync, membership and billing, telemetry, hosted providers, desktop update and signing, iOS relay, internal DevTools, Server, Web, and private evaluation modules remain excluded
- no dependency, prompt, provider, storage-schema, IPC, or public-contract change

## Verification

- negative control: the expanded regression failed on clean `origin/main` before the runtime patch
- `npm run test:js -- test/main/features/local_agents/context.test.ts` — 12 passed
- `npm run typecheck` — passed
- `npm run smoke` — passed; its expected missing-template recovery warning remained structurally redacted
- `npm run test:e2e -- test/e2e/app_e2e_smoke.spec.ts` — 4 passed, covering real relaunch, hidden renderer/preload startup, stable key surfaces, and primary navigation; only the existing Playwright `NO_COLOR`/`FORCE_COLOR` environment notice was emitted
- `git diff --check origin/main...HEAD` — passed
- OSS boundary checks report zero forbidden-symbol, forbidden-file, provider/API, orphan-import, UI, credit-connector, package, TypeScript, renderer-syntax, and renderer-symbol violations
- the full OSS postcheck reproduces the same two unrelated repository-baseline failures on clean `origin/main`: one target-owned builtin-resource source-hash drift and three stale exclusion-review entries outside this isolated source range