### PR TITLE
fix: keep private diagnostics out of logs and terminal output

### DIFF
--- a/src/main/features/connectors/mcp-client.ts
+++ b/src/main/features/connectors/mcp-client.ts
@@ -99,12 +99,17 @@ export class McpConnection {
         argCount: this.transport.args.length,
         proxyMode: proxyEnv.ORKAS_PROXY_MODE || 'unmanaged',
       });
-      transport = new sdk.StdioClientTransport({
+      const stdioTransport = new sdk.StdioClientTransport({
         command: this.transport.command,
         args: this.transport.args,
         env: envFull,
+        stderr: 'pipe',
         ...(this.transport.cwd ? { cwd: this.transport.cwd } : {}),
       });
+      // Provider diagnostics can contain credentials or user data. Drain without
+      // retaining them; lifecycle and request errors use the host's structured logs.
+      stdioTransport.stderr?.on('data', () => {});
+      transport = stdioTransport;
     } else {
       const url = new URL(this.transport.url);
       // A custom URL may carry credentials in the query string (`?key=…`); log

--- a/src/main/util/log-sanitize.ts
+++ b/src/main/util/log-sanitize.ts
@@ -40,7 +40,9 @@ const QUERY_SECRET_FIELD_RE = new RegExp(
   'gi',
 );
 
-const PATH_END = '(?=\\s+(?:then|while|failed|failure|error|at|from|to|for|because|with)\\b|$|[\'",);])';
+// A newline ends a path too: child_process errors ("Command failed: node
+// /Users/x/tool.js\nError: …") would otherwise leave the path unmasked.
+const PATH_END = '(?=\\s+(?:then|while|failed|failure|error|at|from|to|for|because|with)\\b|$|[\\r\\n\'",);])';
 const CLOUD_PATH_RE = new RegExp(`\\bcloud\\/[^\\n\\r'",);]+?${PATH_END}`, 'g');
 const FILE_URL_RE = new RegExp(`\\bfile:\\/\\/\\/?[^\\n\\r'",);]+?${PATH_END}`, 'gi');
 const POSIX_ABS_PATH_RE = new RegExp(`(^|[\\s'",(])((?:\\/Users|\\/private|\\/var|\\/tmp|\\/Volumes|\\/home|\\/opt)\\/[^\\n\\r'",);]+?)${PATH_END}`, 'g');

--- a/test/main/features/connectors/mcp-client.test.ts
+++ b/test/main/features/connectors/mcp-client.test.ts
@@ -1,0 +1,55 @@
+import { spawnSync } from 'node:child_process';
+import { createRequire } from 'node:module';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+const require = createRequire(import.meta.url);
+
+describe('MCP stdio diagnostic boundary', () => {
+  it.each(['custom-fixture', 'notion'])('drains private child diagnostics without inheriting them into the parent: %s', (id) => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'orkas-mcp-diagnostics-'));
+    const childPath = path.join(root, 'server.cjs');
+    const probePath = path.join(root, 'probe.cjs');
+    const marker = 'synthetic-private-connector-diagnostic';
+    fs.writeFileSync(childPath, [
+      `const { Server } = require(${JSON.stringify(require.resolve('@modelcontextprotocol/sdk/server/index.js'))});`,
+      `const { StdioServerTransport } = require(${JSON.stringify(require.resolve('@modelcontextprotocol/sdk/server/stdio.js'))});`,
+      `const { ListToolsRequestSchema } = require(${JSON.stringify(require.resolve('@modelcontextprotocol/sdk/types.js'))});`,
+      "const server = new Server({ name: 'fixture', version: '1.0.0' }, { capabilities: { tools: {} } });",
+      "server.setRequestHandler(ListToolsRequestSchema, async () => ({ tools: [{ name: 'read_fixture', inputSchema: { type: 'object' } }] }));",
+      // More than a typical pipe buffer: the privacy boundary must drain the stream too.
+      `process.stderr.write(${JSON.stringify(marker)}.repeat(4096));`,
+      'process.stdin.once("end", () => { void server.close(); });',
+      'void server.connect(new StdioServerTransport());',
+    ].join('\n'));
+    fs.writeFileSync(probePath, [
+      `require.cache[require.resolve(${JSON.stringify(path.resolve('src/main/logger.ts'))})] = { exports: { createLogger: () => ({ info() {}, warn() {} }) } };`,
+      `require.cache[require.resolve(${JSON.stringify(path.resolve('src/main/util/proxy-dispatcher.ts'))})] = { exports: { buildChildProxyEnvironment: async () => ({}) } };`,
+      `const { McpConnection } = require(${JSON.stringify(path.resolve('src/main/features/connectors/mcp-client.ts'))});`,
+      `const connection = new McpConnection(${JSON.stringify(id)}, { kind: 'stdio', command: process.execPath, args: [${JSON.stringify(childPath)}], env: { ELECTRON_RUN_AS_NODE: '1' } });`,
+      '(async () => {',
+      '  try {',
+      '    await connection.connect();',
+      '    process.stdout.write(JSON.stringify(await connection.listTools()));',
+      '  } finally { await connection.close(); }',
+      '})().catch(() => { process.exitCode = 1; });',
+    ].join('\n'));
+    try {
+      const result = spawnSync(process.execPath, ['-r', require.resolve('tsx/cjs'), probePath], {
+        cwd: root,
+        env: { ...process.env, ELECTRON_RUN_AS_NODE: '1', ORKAS_WORKSPACE_ROOT: root },
+        encoding: 'utf8', timeout: 15_000, maxBuffer: 1024 * 1024,
+      });
+      expect(result.status).toBe(0);
+      expect(JSON.parse(result.stdout)).toEqual([
+        { name: 'read_fixture', description: '', input_schema: { type: 'object' } },
+      ]);
+      expect(result.stderr).toBe('');
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/test/main/util/log-sanitize.test.ts
+++ b/test/main/util/log-sanitize.test.ts
@@ -75,6 +75,14 @@ describe('sanitizeLogTextForUpload › set A (must be masked)', () => {
     expect(out).not.toContain('Secret Project');
   });
 
+  it('masks an absolute path that ends at a newline (child_process error shape)', () => {
+    const out = sanitizeLogTextForUpload('Command failed: node /Users/test/Secret Project/tool.js\nError: boom');
+    expect(out).toContain('<abs-path:');
+    expect(out).not.toContain('/Users/test');
+    expect(out).not.toContain('Secret Project');
+    expect(out).toContain('\nError: boom');
+  });
+
   it('masks Windows absolute paths', () => {
     const out = sanitizeLogTextForUpload('copy C:\\Users\\Alice\\Private\\token.txt failed');
     expect(out).toContain('<abs-path:');


### PR DESCRIPTION
Prevent local MCP servers from writing private diagnostics directly into the parent terminal. Their stderr is piped and drained without retention, including output larger than a typical pipe buffer. Also redact absolute paths immediately before line breaks in command-failure logs while preserving the following error context.

Validation:

- The three new regression scenarios fail before the fixes; the focused logger and connector suite passes all 82 tests afterward. Existing recovery-warning signatures match clean main.
- Full JavaScript suite: 8,608 passed, 15 skipped. Resource tests: 415 passed using an existing Python environment with pytest; the initial default-Python attempt lacked pytest.
- Application and E2E TypeScript checks pass. Platform-native suite: 1,020 passed, 12 skipped. Startup smoke passes, including its expected missing-template recovery warning.
- Ten additional LF/CRLF path-boundary probes pass.
- Desktop E2E: 143 passed, 1 failed. The same ContentWriter process-body assertion fails at commander_e2e_orchestration.spec.ts:67 on unmodified main with the same prepared runtime assets. This is an existing baseline failure; no orchestration or renderer code is changed.
- GitHub Linux x64 and arm64 source checks both pass.
- The four changed files pass the existing forbidden-file, forbidden-symbol and provider-change rules. No dependencies or provider/account behavior are changed.

The complete sync postcheck remains deferred: the same 24 pre-existing findings reproduce on clean main at 1cd3b9d73 (18 symbol findings, 3 documentation paths, 1 UI invariant, 1 resource-parity gate and 1 full-sync coverage gate). The applicable boundary sections match exactly between baseline and this branch. This small patch does not change sync rules or advance the full-sync baseline.

Log review: expected fault-injection and recovery diagnostics remain visible, with no new focused-suite warning signatures. Playwright emits its existing NO_COLOR/FORCE_COLOR notice. The current E2E harness retains Electron logs only for failed cases, so passing-case runtime logs are not available for a complete post-run audit.
