### PR TITLE
fix(library): index user documents and clean stale excluded rows

### DIFF
--- a/src/main/features/kb_indexer.ts
+++ b/src/main/features/kb_indexer.ts
@@ -64,7 +64,7 @@ function corpusFor(uid: string): LibraryCorpus {
     imageSessionPrefix: 'extract-img',
     // Root-level `_INDEX.md` is generated for Finder browsing, and subdirectory
     // copies are pre-vector-store legacy — neither is KB content.
-    skipRelPath: (relPath) => relPath.endsWith('_INDEX.md'),
+    skipRelPath: (relPath) => path.posix.basename(relPath) === '_INDEX.md',
     emit: (event: CorpusStatusEvent) => {
       const out: KbStatusEvent = {
         userId: uid,

--- a/src/main/features/library_corpus.ts
+++ b/src/main/features/library_corpus.ts
@@ -307,7 +307,10 @@ function createCorpus(spec: CorpusSpec): LibraryCorpus {
     if (discarded()) return;
     const safe = safeCorpusRelPath(relPath);
     if (!safe) return;
-    if (spec.skipRelPath?.(safe)) return;
+    // Skipped paths are never indexed, but a row indexed before the skip rule
+    // (or under an older rule) must still be deletable, or reconcile keeps a
+    // stale searchable row forever.
+    if (op === 'upsert' && spec.skipRelPath?.(safe)) return;
     if (op === 'upsert' && !libraryKindFor(safe)) return;
     const existing = queue.jobs.find((job) => job.relPath === safe && job.op === op);
     if (existing) {

--- a/test/main/features/kb_indexer.test.ts
+++ b/test/main/features/kb_indexer.test.ts
@@ -491,17 +491,35 @@ describe('kb_indexer › reconcile', () => {
     writeCtx('.hidden/junk.md', 'should be skipped');   // dot-dir (same rule as .kb/)
     writeCtx('_INDEX.md', '# index');                   // generated file
     writeCtx('sub/_INDEX.md', '# sub index');           // legacy subdir index (also .md but name-filtered)
+    writeCtx('docs/API_INDEX.md', '# a user document whose name merely ends in _INDEX.md');
 
     const idx = await import('../../../src/main/features/kb_indexer');
     const r = await idx.reconcile(TEST_UID);
-    expect(r.enqueuedUpsert).toBe(1);
+    expect(r.enqueuedUpsert).toBe(2);
 
     await idx.drain(TEST_UID);
     const kb = await import('../../../src/main/features/kb_vector');
     expect(kb.getFileByPath(TEST_UID, 'a.md')).not.toBeNull();
+    expect(kb.getFileByPath(TEST_UID, 'docs/API_INDEX.md')).not.toBeNull();
     expect(kb.getFileByPath(TEST_UID, '_INDEX.md')).toBeNull();
     expect(kb.getFileByPath(TEST_UID, 'sub/_INDEX.md')).toBeNull();
     expect(kb.getFileByPath(TEST_UID, '.hidden/junk.md')).toBeNull();
+  });
+
+  it('still deletes a previously indexed row whose path the skip rule now excludes', async () => {
+    // A row indexed under an older rule must not stay searchable forever just
+    // because new upserts of that path are skipped.
+    const kb = await import('../../../src/main/features/kb_vector');
+    const idx = await import('../../../src/main/features/kb_indexer');
+    await kb.setFileStatus(TEST_UID, 'sub/_INDEX.md', 'ready', {
+      kind: 'text', bytes: 1, mtime: 1, sha1: 'stale', error: '',
+    });
+    expect(kb.getFileByPath(TEST_UID, 'sub/_INDEX.md')).not.toBeNull();
+
+    const r = await idx.reconcile(TEST_UID);
+    expect(r.enqueuedDelete).toBe(1);
+    await idx.drain(TEST_UID);
+    expect(kb.getFileByPath(TEST_UID, 'sub/_INDEX.md')).toBeNull();
   });
 
   it('re-enqueues files previously marked failed', async () => {


### PR DESCRIPTION
Fix two Library indexing regressions: user documents such as `docs/API_INDEX.md` must remain indexable, and reconciliation must remove stale rows for generated `_INDEX.md` files that older versions indexed.

Match the generated filename exactly and apply the exclusion only to upserts. Deletion removes derived index data, leaving source files intact. The change touches two runtime conditions and their regression coverage in three files.

Validation on `ca166dffa8d8c86ebd3873d0c9f4a39aca53b535`:

- Both regression scenarios fail on unchanged main and pass with the fix; 84 focused Library, search, vector-storage, transfer and IPC tests pass.
- Full automated suite: 554 files, 8,609 tests passed / 15 skipped; resource tests: 415 passed.
- Platform-native suite: 33 files, 1,020 tests passed / 12 skipped.
- Desktop E2E: 144 passed (19.6 minutes).
- Application and E2E TypeScript checks and startup smoke pass. Linux x64 and arm64 GitHub CI pass.

Earlier overlapping local runs were interrupted after unrelated timing failures; the results above are from completed serial reruns. Focused diagnostic output matches existing fault-injection cases. Smoke emits the expected missing-template warning. The existing E2E harness retains full Electron runtime logs only for failed cases, which limits runtime-log auditing for passing cases.

The changed files have no forbidden-file, forbidden-symbol or provider-change matches. The full synchronization postcheck remains Deferred with 23 hard findings also present on unchanged main; its boundary findings are unchanged. These three backported paths additionally differ from the older pinned full-sync inventory. This small patch does not advance that baseline, relax the rules, or resolve the full-sync backlog.
