### PR TITLE
fix(chat): handle large local text attachments safely

### DIFF
--- a/src/main/features/chat_attachments.ts
+++ b/src/main/features/chat_attachments.ts
@@ -87,7 +87,12 @@ export const ALLOWED_EXTENSIONS: ReadonlySet<string> = new Set([
   ...IMAGE_EXTS, ...VIDEO_EXTS, ...AUDIO_EXTS, ...ARCHIVE_EXTS,
 ]);
 
-const MAX_BYTES_TEXT  = 5   * 1024 * 1024;
+// Text attachments are path-addressed and read by the model in bounded slices,
+// so their composer cap does not need to mirror a prompt/body upload limit.
+// Keep this aligned with the existing context/task local-file ceiling while
+// leaving Project Library's eager indexing boundary unchanged.
+export const MAX_TEXT_ATTACHMENT_BYTES = 200 * 1024 * 1024;
+const MAX_BYTES_TEXT = MAX_TEXT_ATTACHMENT_BYTES;
 const MAX_BYTES_DOCX  = 20  * 1024 * 1024;
 const MAX_BYTES_OFFICE = 50 * 1024 * 1024;
 export const MAX_IMAGE_ATTACHMENT_BYTES = 20 * 1024 * 1024;
@@ -482,6 +487,22 @@ function hashFile(absPath: string): Promise<string> {
   });
 }
 
+async function isUtf8File(absPath: string): Promise<boolean> {
+  const decoder = new TextDecoder('utf-8', { fatal: true, ignoreBOM: true });
+  try {
+    for await (const chunk of fs.createReadStream(absPath)) {
+      decoder.decode(chunk as Buffer, { stream: true });
+    }
+    decoder.decode();
+    return true;
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException)?.code === 'ERR_ENCODING_INVALID_ENCODED_DATA') {
+      return false;
+    }
+    throw err;
+  }
+}
+
 async function findDuplicateByHash(
   dir: string,
   bytes: number,
@@ -618,11 +639,10 @@ export async function importAttachmentFromPath(
     return { ok: false, error: t('errors.file_too_large_mb', { mb: Math.round(cap / 1024 / 1024) }) };
   }
   if (TEXT_EXTS.has(ext)) {
-    let buf: Buffer;
-    try { buf = fs.readFileSync(absSource); }
+    let validUtf8: boolean;
+    try { validUtf8 = await isUtf8File(absSource); }
     catch (err) { return { ok: false, error: (err as Error).message }; }
-    const s = buf.toString('utf8');
-    if (Buffer.from(s, 'utf8').length !== buf.length) {
+    if (!validUtf8) {
       return { ok: false, error: t('errors.not_utf8') };
     }
   }
@@ -651,7 +671,7 @@ export async function importAttachmentFromPath(
 
     const target = uniqueTarget(dir, safeName);
     const finalName = path.basename(target);
-    try { fs.copyFileSync(absSource, target); }
+    try { await fs.promises.copyFile(absSource, target); }
     catch (err) {
       try {
         if (fs.readdirSync(dir).length === 0) fs.rmdirSync(dir);

--- a/src/main/features/chat_attachments.ts
+++ b/src/main/features/chat_attachments.ts
@@ -555,7 +555,7 @@ export async function uploadAttachment(
   }
   if (TEXT_EXTS.has(ext)) {
     const s = buf.toString('utf8');
-    if (Buffer.from(s, 'utf8').length !== buf.length) {
+    if (!Buffer.from(s, 'utf8').equals(buf)) {
       return { ok: false, error: t('errors.not_utf8') };
     }
   }

--- a/src/main/ipc/index.ts
+++ b/src/main/ipc/index.ts
@@ -1864,8 +1864,7 @@ const invokeHandlers: Record<string, InvokeHandler> = {
     for (const filePath of picked) {
       const name = path.basename(filePath);
       try {
-        const buf = fs.readFileSync(filePath);
-        const res = await chatAttachments.uploadAttachment(ctx.userId, cid, name, buf);
+        const res = await chatAttachments.importAttachmentFromPath(ctx.userId, cid, filePath, name);
         if (res.ok) items.push({ displayName: name, info: res.info, reused: !!res.reused });
         else failed.push({ name, error: (res as any).error });
       } catch (err) {

--- a/test/main/features/chat_attachments.test.ts
+++ b/test/main/features/chat_attachments.test.ts
@@ -360,6 +360,38 @@ describe('chat_attachments › uploadAttachment', () => {
     expect(fs.readFileSync(path.join(attDir(), 'workspace-note.md'), 'utf8')).toBe('# hello\n');
   });
 
+  it('imports text files above the legacy 5 MiB cap by path', async () => {
+    const m = await loadMod();
+    const source = path.join(tmpDir, 'large-events.csv');
+    const bytes = 6 * 1024 * 1024;
+    fs.writeFileSync(source, Buffer.alloc(bytes, 0x61));
+
+    const r = await m.importAttachmentFromPath(UID, CID, source);
+
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.info).toMatchObject({
+      name: 'large-events.csv',
+      kind: 'text',
+      bytes,
+    });
+    expect(fs.statSync(path.join(attDir(), 'large-events.csv')).size).toBe(bytes);
+  });
+
+  it('keeps the text attachment boundary at 200 MiB', async () => {
+    const m = await loadMod();
+    const source = path.join(tmpDir, 'too-large.csv');
+    fs.closeSync(fs.openSync(source, 'w'));
+    fs.truncateSync(source, 200 * 1024 * 1024 + 1);
+
+    const r = await m.importAttachmentFromPath(UID, CID, source);
+
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.error).toContain('200');
+    expect(fs.existsSync(path.join(attDir(), 'too-large.csv'))).toBe(false);
+  });
+
   it('reuses an existing attachment when imported file hash matches', async () => {
     const m = await loadMod();
     const r1 = await m.uploadAttachment(UID, CID, 'kept.md', Buffer.from('same body'));
@@ -416,7 +448,9 @@ describe('chat_attachments › uploadAttachment', () => {
     if (!results.every((r) => r.ok)) return;
     expect(new Set(results.map((r) => r.info.name)).size).toBe(1);
     expect(results.filter((r) => r.reused).length).toBe(1);
-    expect(fs.readdirSync(attDir()).filter((n) => !n.startsWith('.'))).toEqual(['source-a.md']);
+    const canonicalName = results[0].info.name;
+    expect(['source-a.md', 'source-b.md']).toContain(canonicalName);
+    expect(fs.readdirSync(attDir()).filter((n) => !n.startsWith('.'))).toEqual([canonicalName]);
   });
 
   it('validates text encoding when importing by path', async () => {
@@ -428,6 +462,21 @@ describe('chat_attachments › uploadAttachment', () => {
 
     expect(r.ok).toBe(false);
     expect(fs.existsSync(path.join(attDir(), 'bad.txt'))).toBe(false);
+  });
+
+  it('detects invalid UTF-8 after the legacy 5 MiB boundary', async () => {
+    const m = await loadMod();
+    const source = path.join(tmpDir, 'large-invalid.txt');
+    const body = Buffer.alloc(6 * 1024 * 1024, 0x61);
+    body[body.length - 1] = 0xFF;
+    fs.writeFileSync(source, body);
+
+    const r = await m.importAttachmentFromPath(UID, CID, source);
+
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.error.toLowerCase()).toContain('utf-8');
+    expect(fs.existsSync(path.join(attDir(), 'large-invalid.txt'))).toBe(false);
   });
 });
 

--- a/test/main/features/chat_attachments.test.ts
+++ b/test/main/features/chat_attachments.test.ts
@@ -242,10 +242,31 @@ describe('chat_attachments › uploadAttachment', () => {
     expect(fs.existsSync(path.join(attDir(), 'huge.mp4'))).toBe(false);
   });
 
-  it('rejects non-UTF-8 content for text types', async () => {
+  it.each([
+    { label: 'invalid leading bytes', bytes: [0xFF, 0xFE] },
+    { label: 'truncated four-byte character', bytes: [0xF0, 0x9F, 0x92] },
+    { label: 'interrupted four-byte character', bytes: [0xF0, 0x90, 0x80, 0x41] },
+    { label: 'truncated three-byte character', bytes: [0xE2, 0x82] },
+    { label: 'surrogate encoding', bytes: [0xED, 0xA0, 0x80] },
+  ])('rejects non-UTF-8 content for text types: $label', async ({ bytes }) => {
     const m = await loadMod();
-    const r = await m.uploadAttachment(UID, CID, 'bad.txt', Buffer.from([0xFF, 0xFE]));
+    const buffer = Buffer.from(bytes);
+    const r = await m.uploadAttachment(UID, CID, 'bad.txt', buffer);
     expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error.toLowerCase()).toContain('utf-8');
+    expect(m.listAttachments(UID, CID)).toEqual([]);
+    const source = path.join(tmpDir, 'bad.txt');
+    fs.writeFileSync(source, buffer);
+    expect((await m.importAttachmentFromPath(UID, CID, source)).ok).toBe(false);
+    expect(fs.readFileSync(source)).toEqual(buffer);
+    expect(m.listAttachments(UID, CID)).toEqual([]);
+  });
+
+  it('preserves valid Unicode and an authored replacement character byte for byte', async () => {
+    const m = await loadMod();
+    const buffer = Buffer.from('\uFEFF中文 📝 \uFFFD');
+    expect((await m.uploadAttachment(UID, CID, 'unicode.txt', buffer)).ok).toBe(true);
+    expect(fs.readFileSync(path.join(attDir(), 'unicode.txt'))).toEqual(buffer);
   });
 
   it('rejects unknown extensions', async () => {

--- a/test/main/ipc/contexts-pick-upload.test.ts
+++ b/test/main/ipc/contexts-pick-upload.test.ts
@@ -190,4 +190,35 @@ describe('conversations.attachments.pickAndUpload', () => {
       failed: [],
     });
   });
+
+  it('imports a text file above 5 MiB through the native picker', async () => {
+    const source = path.join(tmpDir, 'large-events.csv');
+    const bytes = 6 * 1024 * 1024;
+    fs.writeFileSync(source, Buffer.alloc(bytes, 0x61));
+    const electron = await import('electron') as any;
+    electron.dialog.showOpenDialog.mockResolvedValueOnce({
+      canceled: false,
+      filePaths: [source],
+    });
+
+    const res = await invoke('conversations.attachments.pickAndUpload', {
+      cid: 'chat_picker_large_text',
+    });
+
+    expect(res).toMatchObject({
+      ok: true,
+      cancelled: false,
+      failed: [],
+      items: [
+        expect.objectContaining({
+          displayName: 'large-events.csv',
+          info: expect.objectContaining({
+            name: 'large-events.csv',
+            kind: 'text',
+            bytes,
+          }),
+        }),
+      ],
+    });
+  });
 });


### PR DESCRIPTION
Allow local text attachments up to the shared 200 MiB attachment limit without loading the whole file into memory. Path imports now validate UTF-8 incrementally, copy asynchronously, and are used by the native conversation picker.

Also reject malformed UTF-8 uploads by requiring decoded bytes to round-trip exactly. Regression cases cover invalid leading bytes, truncated and interrupted multibyte characters, valid Unicode, large local files, size limits, picker integration, and concurrent deduplication.

Validation:

- Negative controls failed as expected on the old implementations: 4 large-path/picker cases and 2 malformed UTF-8 cases.
- Focused regression suite: 2 files, 108 tests passed.
- Main and core-agent TypeScript checks passed.
- Provider/API changed-file guard, orphan imports, package invariants, renderer syntax, and renderer symbol completeness passed.
- The full synchronization postcheck reports the same 41 pre-existing hard findings on this branch and unchanged `main`; this patch adds no boundary findings and does not advance the pinned full-sync baseline.