### PR TITLE
fix(composer): cancel superseded model menu openings

### DIFF
--- a/src/renderer/modules/composer-model-picker.js
+++ b/src/renderer/modules/composer-model-picker.js
@@ -5,6 +5,7 @@
 
 let _composerModelEntries = [];
 let _composerModelMenu = null;
+let _composerModelOpening = null;
 let _composerModelBusy = false;
 let _composerModelOptionsByProvider = new Map();
 const _composerModelLog = createLogger('composer-model-picker');
@@ -228,6 +229,7 @@ async function _refreshComposerModelOptions(entries) {
 }
 
 function _closeComposerModelMenu() {
+  _composerModelOpening = null;
   if (!_composerModelMenu) return;
   _closeComposerModelVersionMenu();
   const {
@@ -677,15 +679,21 @@ function _buildComposerModelMenuGroup(group, activeEntryId, anchor) {
 
 async function _toggleComposerModelMenu(anchor) {
   if (!anchor || anchor.disabled) return;
-  if (_composerModelMenu) {
-    const wasSameAnchor = _composerModelMenu.anchor === anchor;
+  if (_composerModelMenu || _composerModelOpening) {
+    const wasSameAnchor = (_composerModelMenu || _composerModelOpening).anchor === anchor;
     _closeComposerModelMenu();
     if (wasSameAnchor) return;
   }
   _closeOtherComposerPopovers('model');
 
+  const opening = { anchor };
+  _composerModelOpening = opening;
   await _refreshComposerModelEntries();
+  if (_composerModelOpening !== opening) return;
   await _refreshComposerModelOptions(_composerModelEntries);
+  if (_composerModelOpening !== opening) return;
+  _composerModelOpening = null;
+  if (anchor.disabled || !anchor.isConnected) return;
   const menu = document.createElement('div');
   menu.id = 'composer-model-menu';
   menu.className = 'composer-model-menu';
@@ -766,7 +774,9 @@ async function _toggleComposerModelMenu(anchor) {
     versionOwner: null,
     versionCloseTimer: null,
   };
-  setTimeout(() => document.addEventListener('mousedown', onOutside), 0);
+  setTimeout(() => {
+    if (_composerModelMenu?.element === menu) document.addEventListener('mousedown', onOutside);
+  }, 0);
   document.addEventListener('keydown', onKeydown);
   window.addEventListener('resize', onViewportChange);
   window.addEventListener('scroll', onViewportChange, true);
@@ -794,14 +804,14 @@ document.addEventListener('DOMContentLoaded', () => {
       window.orkas.onPushEvent('client-config:changed', (payload) => {
         const keys = Array.isArray(payload && payload.keys) ? payload.keys : [];
         if (!keys.includes('model_catalog')) return;
-        if (_composerModelMenu) _closeComposerModelMenu();
+        _closeComposerModelMenu();
         _refreshComposerModelEntries().catch(() => {});
       });
     }
   } catch (_) {}
   window.addEventListener('i18n-change', () => {
     _renderComposerModelChips();
-    if (_composerModelMenu) _closeComposerModelMenu();
+    _closeComposerModelMenu();
   });
   _refreshComposerModelEntries().catch(() => {});
 });

--- a/test/renderer/composer-popover-coordination.test.ts
+++ b/test/renderer/composer-popover-coordination.test.ts
@@ -85,7 +85,151 @@ function closeRecipientPicker(preserveAtKey: boolean) {
   `);
 }
 
+// Run the whole classic script. Only DOM/IPC boundaries are simulated; the
+// async open/close flow and the peer coordination functions stay real.
+function delayedModelPicker() {
+  class Element {
+    id = '';
+    disabled = false;
+    isConnected = true;
+    dataset: Record<string, string> = {};
+    style: Record<string, string> = {};
+    attributes: Record<string, string> = {};
+    children: Element[] = [];
+    classes = new Set<string>();
+    classList = {
+      add: (name: string) => this.classes.add(name),
+      remove: (name: string) => this.classes.delete(name),
+    };
+    setAttribute(name: string, value: string) { this.attributes[name] = value; }
+    appendChild(child: Element) { this.children.push(child); }
+    remove() { body.children = body.children.filter((child) => child !== this); }
+    contains(child: Element) { return child === this || this.children.includes(child); }
+    querySelector() { return null; }
+    addEventListener() {}
+    getBoundingClientRect() { return { right: 100, width: 100, height: 50 }; }
+  }
+  const body = new Element();
+  const listeners = new Map<string, Set<unknown>>();
+  const eventTarget = {
+    addEventListener(name: string, listener: unknown) {
+      if (!listeners.has(name)) listeners.set(name, new Set());
+      listeners.get(name)!.add(listener);
+    },
+    removeEventListener(name: string, listener: unknown) { listeners.get(name)?.delete(listener); },
+  };
+  const pending: Array<() => void> = [];
+  const timers: Array<() => void> = [];
+  const context = vm.createContext({
+    document: {
+      ...eventTarget, body,
+      createElement: () => new Element(),
+      getElementById: () => null,
+      querySelectorAll: () => [],
+      querySelector: () => null,
+    },
+    window: {
+      ...eventTarget, innerWidth: 1000, innerHeight: 800,
+      orkas: { invoke: () => new Promise((resolve) => pending.push(() => resolve({ ok: true, entries: [] }))) },
+    },
+    createLogger: () => ({ warn() {} }),
+    t: (key: string) => key,
+    escapeHtml: (value: string) => value,
+    _dropdownVerticalPlacement: () => ({ top: 10, availableHeight: 500 }),
+    setTimeout: (fn: () => void) => { timers.push(fn); return timers.length; },
+    clearTimeout() {},
+  });
+  vm.runInContext(modelSource, context);
+  const api = vm.runInContext('({ open: _toggleComposerModelMenu, close: _closeComposerModelMenu, peer: _closeOtherComposerPopovers })', context);
+  return {
+    ...api,
+    anchor: () => new Element(),
+    release: () => pending.splice(0).forEach((resolve) => resolve()),
+    flushTimers: () => timers.splice(0).forEach((fn) => fn()),
+    menus: () => body.children.filter((child) => child.id === 'composer-model-menu'),
+    listenerCount: () => ['mousedown', 'keydown', 'resize', 'scroll']
+      .reduce((count, name) => count + (listeners.get(name)?.size || 0), 0),
+  };
+}
+
 describe('composer popover coordination', () => {
+  it('does not install an outside listener after an opened model panel is closed', async () => {
+    const picker = delayedModelPicker();
+    const opening = picker.open(picker.anchor());
+    picker.release();
+    await opening;
+    expect(picker.menus()).toHaveLength(1);
+    picker.close();
+    picker.flushTimers();
+    expect(picker.menus()).toHaveLength(0);
+    expect(picker.listenerCount()).toBe(0);
+  });
+
+  it('cancels a delayed model opening when the same anchor is toggled again', async () => {
+    const picker = delayedModelPicker();
+    const anchor = picker.anchor();
+    const first = picker.open(anchor);
+    const second = picker.open(anchor);
+    picker.release();
+    await Promise.all([first, second]);
+    picker.flushTimers();
+    expect(picker.menus()).toHaveLength(0);
+    expect(anchor.classes.has('is-open')).toBe(false);
+    expect(picker.listenerCount()).toBe(0);
+    const retry = picker.open(anchor);
+    picker.release();
+    await retry;
+    expect(picker.menus()).toHaveLength(1);
+    expect(anchor.attributes['aria-expanded']).toBe('true');
+    picker.close();
+    picker.flushTimers();
+    expect(picker.menus()).toHaveLength(0);
+    expect(anchor.attributes['aria-expanded']).toBe('false');
+    expect(picker.listenerCount()).toBe(0);
+  });
+
+  it('keeps only the latest anchor when two model openings overlap', async () => {
+    const picker = delayedModelPicker();
+    const firstAnchor = picker.anchor();
+    const lastAnchor = picker.anchor();
+    const first = picker.open(firstAnchor);
+    const last = picker.open(lastAnchor);
+    picker.release();
+    await Promise.all([first, last]);
+    picker.flushTimers();
+    expect(picker.menus()).toHaveLength(1);
+    expect(firstAnchor.classes.has('is-open')).toBe(false);
+    expect(lastAnchor.attributes['aria-expanded']).toBe('true');
+    picker.close();
+    expect(picker.menus()).toHaveLength(0);
+    expect(picker.listenerCount()).toBe(0);
+  });
+
+  it.each(['recipient', 'workspace'])('does not reopen the model panel after %s takes over', async (peer) => {
+    const picker = delayedModelPicker();
+    const anchor = picker.anchor();
+    const opening = picker.open(anchor);
+    picker.peer(peer);
+    picker.release();
+    await opening;
+    picker.flushTimers();
+    expect(picker.menus()).toHaveLength(0);
+    expect(anchor.classes.has('is-open')).toBe(false);
+    expect(picker.listenerCount()).toBe(0);
+  });
+
+  it('does not open a model menu after its recipient disables the anchor', async () => {
+    const picker = delayedModelPicker();
+    const anchor = picker.anchor();
+    const opening = picker.open(anchor);
+    anchor.disabled = true;
+    picker.release();
+    await opening;
+    picker.flushTimers();
+    expect(picker.menus()).toHaveLength(0);
+    expect(picker.listenerCount()).toBe(0);
+  });
+
   it('closes recipient and workspace panels before opening the model panel', () => {
     expect(peerCloseResult('model')).toEqual({ model: 0, recipient: 1, workspace: 1 });
   });


### PR DESCRIPTION
Opening the composer model menu loads entries asynchronously. Repeated clicks or switching to the recipient/workspace picker could let an older request reopen the menu or create duplicate panels. Closing a panel could also leave a delayed outside-click listener behind.

Track the pending opening, cancel superseded requests, and attach the delayed listener only while its panel remains open. Preserve the existing model configuration and selection behavior.

Validation:

- All six added regression scenarios fail before the fix; all 15 composer picker/popover tests pass with it. The three existing model-picker desktop E2E scenarios also pass.
- Main/core-agent and E2E typechecks pass. JavaScript: 554 files, 8,624 passed and 15 skipped. Resources: 415 passed. Native platform: 1,020 passed and 12 skipped. Startup smoke passes.
- Full desktop E2E: 142 passed, two existing attachment failures. Both failures reproduce on unchanged main: those cases still reject text above 5 MiB, while #64 raised the supported text limit to 200 MiB. Their expectations are unchanged here.
- Linux x64 and arm64 GitHub checks pass. Existing fault-injection diagnostics, color-environment warnings and a resource-load error reproduced on the baseline remain; passing E2E cases do not retain full Electron logs, so this is not a clean-runtime-log claim.
