### PR TITLE
feat(providers): add API Route preset

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **Command a team of AI agents from one desktop chat — not one chatbot.**
 
-Orkas is an open-source, local-first multi-agent desktop app. Describe a goal; its **Commander** plans the work, handles the general parts itself, and coordinates specialist agents in parallel or in sequence. **Nine specialist agents ship with the app**, ready the moment you launch it, out of 30 in the marketplace. Bring your own model keys — Claude · OpenAI · Gemini · DeepSeek · Kimi · GLM · Qwen · MiniMax · Doubao. macOS · Windows · Linux.
+Orkas is an open-source, local-first multi-agent desktop app. Describe a goal; its **Commander** plans the work, handles the general parts itself, and coordinates specialist agents in parallel or in sequence. **Nine specialist agents ship with the app**, ready the moment you launch it, out of 30 in the marketplace. Bring your own model keys — Claude · OpenAI · Gemini · DeepSeek · Kimi · GLM · Qwen · MiniMax · Doubao · API Route. macOS · Windows · Linux.
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](./LICENSE)
 [![Stars](https://img.shields.io/github/stars/Orkas-AI/Orkas?style=social)](https://github.com/Orkas-AI/Orkas/stargazers)

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -2,7 +2,7 @@
 
 **在一个桌面对话里指挥一支 AI 智能体团队 —— 而不是单个聊天机器人。**
 
-Orkas 是一个开源、本地优先的多智能体桌面应用。你描述目标，**指挥官**规划路径、亲自完成通用部分，并调度专业智能体并行或串行执行。**9 个专业智能体随应用内置**，启动即可用，marketplace 中共有 30 个。自带模型 key —— Claude · OpenAI · Gemini · DeepSeek · Kimi · GLM · Qwen · MiniMax · Doubao。支持 macOS · Windows · Linux。
+Orkas 是一个开源、本地优先的多智能体桌面应用。你描述目标，**指挥官**规划路径、亲自完成通用部分，并调度专业智能体并行或串行执行。**9 个专业智能体随应用内置**，启动即可用，marketplace 中共有 30 个。自带模型 key —— Claude · OpenAI · Gemini · DeepSeek · Kimi · GLM · Qwen · MiniMax · Doubao · API Route。支持 macOS · Windows · Linux。
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](./LICENSE)
 [![Stars](https://img.shields.io/github/stars/Orkas-AI/Orkas?style=social)](https://github.com/Orkas-AI/Orkas/stargazers)

--- a/src/main/features/auth.ts
+++ b/src/main/features/auth.ts
@@ -83,6 +83,7 @@ import {
   providerSubscriptionNote,
   providerRecommended,
   providerUsesCustomOpenAIConfig,
+  providerCustomPreset,
   sortProviderIds,
   type CustomOpenAICompatibleRuntimeConfig,
 } from '../model/provider_catalog';
@@ -1003,6 +1004,11 @@ export interface ProviderEntry {
   supportsApiKey: boolean;
   supportsOAuth: boolean;
   customOpenAICompatible?: boolean;
+  customPreset?: {
+    label: string;
+    baseUrl: string;
+    model: string;
+  };
   /** If OAuth on this provider actually logs in via a different pi-ai
    *  provider (e.g. `openai` → `openai-codex`), this carries the target id
    *  so the renderer can call `startOAuth(oauthProvider)` accordingly. */
@@ -1116,7 +1122,8 @@ export async function listProviders(): Promise<{ providers: ProviderEntry[] }> {
     const directOAuth = oauthIds.has(id);
     const aliasOAuth  = OAUTH_ALIAS_FOR[id];
     const supportsOAuth = directOAuth || (!!aliasOAuth && oauthIds.has(aliasOAuth));
-    const supportsApiKey = apiCapable.has(id) && !oauthOnlyIds.has(id);
+    const supportsApiKey = (apiCapable.has(id) || providerUsesCustomOpenAIConfig(id))
+      && !oauthOnlyIds.has(id);
     return {
       id,
       label: providerLabel(id),
@@ -1125,6 +1132,7 @@ export async function listProviders(): Promise<{ providers: ProviderEntry[] }> {
       supportsApiKey,
       supportsOAuth,
       customOpenAICompatible: providerUsesCustomOpenAIConfig(id),
+      customPreset: providerCustomPreset(id),
       oauthProvider: directOAuth ? id : (supportsOAuth ? aliasOAuth : undefined),
       docsUrl: providerDocsUrl(id),
       subscriptionNote: providerSubscriptionNote(id),

--- a/src/main/model/provider_catalog.ts
+++ b/src/main/model/provider_catalog.ts
@@ -58,6 +58,11 @@ export interface CatalogEntry {
   oauthOnly?: boolean;        // if true, hide the API-key path entirely
   managedByOrkas?: boolean;   // if true, Orkas Server brokers the model; no user API key is needed
   customOpenAICompatible?: boolean; // user supplies base URL + model metadata
+  customPreset?: {
+    label: string;
+    baseUrl: string;
+    model: string;
+  };
   /** Per-provider prerequisite note shown on the card + the add-key form.
    *  Used when the same "brand" has two independent billing/auth surfaces
    *  (e.g. Moonshot pay-as-you-go open platform vs. Kimi Coding Plan
@@ -80,7 +85,7 @@ export interface CatalogEntry {
 // default via provider_policy.ts; dev builds keep it for local testing.
 // Group 1: global frontier labs (Anthropic, OpenAI, Google)
 // Group 2: China mainstream (Zhipu GLM, Moonshot Kimi, MiniMax)
-// Group 3: aggregators (OpenRouter)
+// Group 3: aggregators (API Route, OpenRouter)
 
 export const CATALOG: readonly CatalogEntry[] = [
   {
@@ -122,6 +127,17 @@ export const CATALOG: readonly CatalogEntry[] = [
   { id: 'doubao',             label: 'Doubao',  docsUrl: 'https://console.volcengine.com/ark/region:ark+cn-beijing/apiKey', region: 'cn',
     subscriptionNote: '' },
 
+  {
+    id: 'api-route',
+    label: 'API Route',
+    docsUrl: 'https://www.api-route.com/api-keys',
+    customOpenAICompatible: true,
+    customPreset: {
+      label: 'API Route',
+      baseUrl: 'https://global.api-route.com/v1',
+      model: 'gpt-5.4-mini',
+    },
+  },
   { id: 'openrouter',         label: 'OpenRouter',    docsUrl: 'https://openrouter.ai/keys' },
   {
     id: 'custom',
@@ -704,6 +720,10 @@ export function providerManagedByOrkas(id: string): boolean {
 
 export function providerUsesCustomOpenAIConfig(id: string): boolean {
   return CATALOG.find((p) => p.id === id)?.customOpenAICompatible === true;
+}
+
+export function providerCustomPreset(id: string): CatalogEntry['customPreset'] {
+  return CATALOG.find((p) => p.id === id)?.customPreset;
 }
 
 export interface CustomOpenAICompatibleRuntimeConfig {

--- a/src/renderer/modules/settings.js
+++ b/src/renderer/modules/settings.js
@@ -1469,8 +1469,9 @@ function _settingsShowCustomModelForm(provider) {
   const actions = document.getElementById('add-account-actions');
   if (!overlay || !title || !body || !actions) return;
 
+  const preset = provider.customPreset || {};
   title.innerHTML = `
-    <span class="modal-title-text">${escapeHtml(t('settings.custom.title'))}</span>
+    <span class="modal-title-text">${escapeHtml(preset.label || t('settings.custom.title'))}</span>
     <span class="form-hint custom-model-intro">${escapeHtml(t('settings.custom.compat_hint'))}</span>
   `;
   body.innerHTML = `
@@ -1505,6 +1506,12 @@ function _settingsShowCustomModelForm(provider) {
   const maxTokensInput = body.querySelector('.custom-max-tokens-input');
   const keyInput = body.querySelector('.custom-key-input');
   const msg = body.querySelector('.form-msg');
+
+  if (provider.customPreset) {
+    labelInput.value = preset.label;
+    baseUrlInput.value = preset.baseUrl;
+    modelInput.value = preset.model;
+  }
 
   const cancelBtn = document.createElement('button');
   cancelBtn.className = 'btn';
@@ -1593,7 +1600,7 @@ function _settingsShowCustomModelForm(provider) {
   actions.appendChild(cancelBtn);
   actions.appendChild(saveBtn);
   _settingsOpenModal(overlay);
-  setTimeout(() => labelInput.focus(), 0);
+  setTimeout(() => (provider.customPreset ? keyInput : labelInput).focus(), 0);
 }
 
 function _settingsOpenModal(overlay) {

--- a/test/main/model/provider_catalog.test.ts
+++ b/test/main/model/provider_catalog.test.ts
@@ -13,6 +13,7 @@ import {
   isVisibleProvider,
   providerLabel,
   providerDocsUrl,
+  providerCustomPreset,
   providerSubscriptionNote,
   sortProviderIds,
   curatedModelsFor,
@@ -28,7 +29,7 @@ describe('provider_catalog › CATALOG', () => {
     expect(new Set(ids).size).toBe(ids.length);
     // DeepSeek 直连先（pi-ai 不带，自建适配），然后全球前沿（OpenAI Codex /
     // OpenAI / Google / Anthropic），CN 主流（Zhipu / Moonshot / Kimi-Coding /
-    // MiniMax × 3 / Doubao），最后聚合器（OpenRouter）。
+    // MiniMax × 3 / Doubao），最后聚合器（API Route / OpenRouter）。
     expect(ids).toEqual([
       'orkas-api',
       'deepseek',
@@ -43,6 +44,7 @@ describe('provider_catalog › CATALOG', () => {
       'minimax-portal-cn',
       'minimax-cn',
       'doubao',
+      'api-route',
       'openrouter',
       'custom',
     ]);
@@ -455,6 +457,14 @@ describe('provider_catalog › labels and docs', () => {
 
   it('providerDocsUrl is undefined for orphan providers', () => {
     expect(providerDocsUrl('huggingface')).toBeUndefined();
+  });
+
+  it('provides the fixed API Route OpenAI-compatible preset', () => {
+    expect(providerCustomPreset('api-route')).toEqual({
+      label: 'API Route',
+      baseUrl: 'https://global.api-route.com/v1',
+      model: 'gpt-5.4-mini',
+    });
   });
 
   it('providerSubscriptionNote 在两条 Moonshot endpoint 上都给出明确前提', () => {

--- a/test/renderer/settings-add-account.test.ts
+++ b/test/renderer/settings-add-account.test.ts
@@ -375,6 +375,47 @@ describe('settings model authorization add account', () => {
     });
   });
 
+  it('prefills the API Route custom provider preset', async () => {
+    const { context, elements, invoke } = loadSettingsClickHarness();
+    const body = elements.get('add-account-body')!;
+    const actions = elements.get('add-account-actions')!;
+    const fields = {
+      '.custom-label-input': '',
+      '.custom-base-url-input': '',
+      '.custom-model-input': '',
+      '.custom-max-tokens-input': '',
+      '.custom-key-input': 'sk-route-test',
+      '.form-msg': '',
+    };
+    for (const [selector, value] of Object.entries(fields)) {
+      const element = new FakeElement();
+      element.value = value;
+      body.setQueryResult(selector, element);
+    }
+
+    context._settingsShowCustomModelForm({
+      id: 'api-route',
+      label: 'API Route',
+      customPreset: {
+        label: 'API Route',
+        baseUrl: 'https://global.api-route.com/v1',
+        model: 'gpt-5.4-mini',
+      },
+    });
+
+    expect(body.querySelector('.custom-label-input')?.value).toBe('API Route');
+    expect(body.querySelector('.custom-base-url-input')?.value)
+      .toBe('https://global.api-route.com/v1');
+    expect(body.querySelector('.custom-model-input')?.value).toBe('gpt-5.4-mini');
+    await actions.children.at(-1)!.click();
+    expect(invoke).toHaveBeenCalledWith('auth.addCustomModelEntry', {
+      label: 'API Route',
+      baseUrl: 'https://global.api-route.com/v1',
+      model: 'gpt-5.4-mini',
+      apiKey: 'sk-route-test',
+    });
+  });
+
   it('shows a localized validation message when main rejects a custom API key header', async () => {
     const { context, elements } = loadSettingsClickHarness(async (channel) => (
       channel === 'auth.addCustomModelEntry'


### PR DESCRIPTION
## Summary

- add API Route to the provider catalog as a branded OpenAI-compatible preset
- prefill the official API base URL and default model so setup only requires an API key
- reuse Orkas' existing custom-provider runtime and local credential storage
- document API Route availability in the English and Chinese READMEs

## Validation

- `npm run typecheck`
- `npx vitest run test/main/model/provider_catalog.test.ts test/renderer/settings-add-account.test.ts` (64 tests passed)

The full JavaScript suite was also sampled with a cached Electron 41 runtime after the Electron 42 binary download was interrupted. The observed failures were in unrelated platform/environment-sensitive suites (Windows paths/processes, video studio, local CLI, and evaluator tests); the targeted provider suites pass.

Disclosure: This contribution was prepared with AI coding assistance and reviewed through targeted tests and type checking.