### PR TITLE
fix(skills): prevent delayed modal focus from redirecting input

### DIFF
--- a/src/renderer/modules/skills.js
+++ b/src/renderer/modules/skills.js
@@ -2474,14 +2474,13 @@ function _switchSkillTab(tab) {
   // Clear error msg when switching tabs
   const msgEl = document.getElementById('skill-form-msg');
   if (msgEl) { msgEl.textContent = ''; msgEl.className = 'form-msg'; }
-  // Focus primary input of the new tab
-  setTimeout(() => {
-    const focusId = tab === 'url' ? 'skill-url-input'
-                  : tab === 'dir' ? 'skill-dir-pick-btn'
-                  : 'skill-name';
-    const el = document.getElementById(focusId);
-    if (el) el.focus();
-  }, 30);
+  // The panel is visible now. A delayed focus can interrupt the user's next
+  // field selection and redirect their input into the wrong field.
+  const focusId = tab === 'url' ? 'skill-url-input'
+                : tab === 'dir' ? 'skill-dir-pick-btn'
+                : 'skill-name';
+  const el = document.getElementById(focusId);
+  if (el) el.focus();
 }
 window._switchSkillTab = _switchSkillTab;
 
@@ -2513,7 +2512,6 @@ async function openSkillModal(editId) {
     saveBtn.textContent = t('common.confirm');
     editIdInput.value = editId;
     if (tabBar) tabBar.style.display = 'none'; // edit mode: no tabs, manual only
-    _switchSkillTab('manual');
     const cached = _skillsCache?.find(s => s.id === editId && s.source === 'custom');
     if (cached) {
       document.getElementById('skill-name').value = cached.name || '';
@@ -2528,7 +2526,6 @@ async function openSkillModal(editId) {
     saveBtn.textContent = t('common.confirm');
     editIdInput.value = '';
     if (tabBar) tabBar.style.display = '';
-    _switchSkillTab('manual');
   }
 
   // Wire tab buttons (idempotent — checks a flag)
@@ -2540,6 +2537,7 @@ async function openSkillModal(editId) {
   }
 
   modal.classList.add('open');
+  _switchSkillTab('manual');
   if (typeof window.bindNameLimitControl === 'function') {
     window.bindNameLimitControl(document.getElementById('skill-name'));
   }

--- a/test/renderer/skill-modal-focus.test.ts
+++ b/test/renderer/skill-modal-focus.test.ts
@@ -1,0 +1,86 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as vm from 'node:vm';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+function loadModal() {
+  const ids = new Map<string, ReturnType<typeof makeElement>>();
+  let active: unknown;
+  function makeElement(id: string, dataset: Record<string, string> = {}) {
+    const classes = new Set<string>();
+    return {
+      id, dataset, value: '', textContent: '', className: '', style: { display: '' },
+      classList: {
+        add: (name: string) => { classes.add(name); },
+        remove: (name: string) => { classes.delete(name); },
+        contains: (name: string) => classes.has(name),
+        toggle: (name: string, on: boolean) => { if (on) classes.add(name); else classes.delete(name); },
+      },
+      setAttribute() {}, addEventListener() {},
+      querySelectorAll: (): unknown[] => tabs,
+      focus() {
+        if (get('skill-modal').classList.contains('open')) active = this;
+      },
+    };
+  }
+  function get(id: string) {
+    if (!ids.has(id)) ids.set(id, makeElement(id));
+    return ids.get(id)!;
+  }
+  const tabs = ['manual', 'url', 'dir'].map((tab) => makeElement(tab, { skillTab: tab }));
+  const panels = ['manual', 'url', 'dir'].map((tab) => makeElement(tab, { skillPanel: tab }));
+  const context = vm.createContext({
+    console, setTimeout, clearTimeout,
+    createLogger: () => ({ warn() {}, info() {}, error() {} }),
+    t: (key: string) => key,
+    window: { addEventListener() {} },
+    document: {
+      getElementById: get,
+      querySelectorAll: (selector: string) => selector === '.skill-modal-tab' ? tabs
+        : selector === '.skill-modal-panel' ? panels : [],
+    },
+  });
+  vm.runInContext(fs.readFileSync(path.join(__dirname, '../../src/renderer/modules/skills.js'), 'utf8'), context);
+  return {
+    get, tabs, panels, active: () => active,
+    open: () => vm.runInContext('openSkillModal()', context) as Promise<void>,
+    switchTab: (tab: string) => vm.runInContext(`_switchSkillTab(${JSON.stringify(tab)})`, context),
+    close: () => vm.runInContext('closeSkillModal()', context),
+  };
+}
+
+describe('skill modal focus lifecycle', () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  it('keeps focus on the description when the user moves there immediately after opening', async () => {
+    const modal = loadModal();
+    await modal.open();
+    modal.get('skill-name').focus();
+    modal.get('skill-name').value = 'desktop-check';
+    modal.get('skill-description').focus();
+    await vi.advanceTimersByTimeAsync(30);
+    expect(modal.active()).toBe(modal.get('skill-description'));
+    expect(modal.get('skill-name').value).toBe('desktop-check');
+  });
+
+  it.each([
+    ['manual', 'skill-name'], ['url', 'skill-url-input'], ['dir', 'skill-dir-pick-btn'],
+  ])('focuses the visible %s panel immediately without leaving delayed focus work', async (tab, id) => {
+    const modal = loadModal();
+    await modal.open();
+    modal.switchTab(tab);
+    expect(modal.active()).toBe(modal.get(id));
+    expect(modal.panels.find((panel) => panel.dataset.skillPanel === tab)?.classList.contains('is-active')).toBe(true);
+    modal.close();
+    const focusedBefore = modal.active();
+    await vi.advanceTimersByTimeAsync(30);
+    expect(modal.active()).toBe(focusedBefore);
+  });
+
+  it('focuses the name when opening the now-visible modal', async () => {
+    const modal = loadModal();
+    await modal.open();
+    expect(modal.active()).toBe(modal.get('skill-name'));
+  });
+});


### PR DESCRIPTION
Opening the skill dialog or switching its tabs scheduled a delayed focus that could move the cursor back to the name field after the user selected the description. Focus the visible panel immediately and initialize the manual panel after the dialog opens.

Adds five deterministic regressions covering initial focus, all three tabs, and preserving the user’s next field selection. Only the renderer and its test change.

Validation:
- All five new regressions fail before the fix; all 19 focused tests pass afterward.
- JavaScript: 555 files, 8,629 passed, 15 skipped. Resources: 415 passed.
- Main/core and E2E type checks, startup smoke, and Linux x64/arm64 CI pass. Native lane: 1,020 passed, 12 skipped.
- Full desktop E2E: 141 passed, 3 failed; all five resource CRUD cases pass, including the skill lifecycle.
- Both attachment failures reproduce on unchanged main: the cases still expect a 5 MiB text limit after it increased to 200 MiB. The CLI recovery case hit a transient empty JSON read of the session-binding file; it passes alone on both unchanged main and this branch. Its test and runtime code are unchanged. The initial failure remains recorded.

Existing validation limits: the full-sync audit reports identical output with 50 findings before and after this patch; its baseline remains unchanged. Linux logs retain the same GLib/Sharp diagnostics and dependency audit findings as the previous run, and passing desktop cases do not retain complete runtime logs. This is not a clean full-suite or clean-log claim.
