### PR TITLE
fix(search): preserve dictionaries when reloading saved indexes

### DIFF
--- a/src/main/features/search/storage.ts
+++ b/src/main/features/search/storage.ts
@@ -34,7 +34,11 @@ const fsp = fs.promises;
 // so existing users get their chat history searchable again on next launch
 // (the alternative — leaving v3 — would only fix newly-modified jsonl files
 // because reconcile keys off mtime+size, not schema correctness).
-export const SCHEMA_VERSION = 4;
+// v5 restores null-prototype dictionaries after JSON loading. Earlier readers
+// could mistake tokens such as `constructor` for inherited properties and
+// persist partially indexed documents. Rebuild those derived snapshots once
+// from source files, even when their recorded mtime/size still matches.
+export const SCHEMA_VERSION = 5;
 
 export type IndexKind = 'context' | 'chat';
 
@@ -76,9 +80,12 @@ export async function loadIndex(idxPath: string, kind: IndexKind): Promise<Index
     const raw = await fsp.readFile(idxPath, 'utf8');
     const idx = JSON.parse(raw);
     if (idx && idx.version === SCHEMA_VERSION && idx.kind === kind) {
-      idx.files    = idx.files    || Object.create(null);
-      idx.docs     = idx.docs     || Object.create(null);
-      idx.postings = idx.postings || Object.create(null);
+      // JSON.parse does not preserve the null prototype used by emptyIndex.
+      // Copy own keys into dictionaries so every filename/token remains data,
+      // including __proto__, and absent terms never resolve through Object.
+      idx.files    = Object.assign(Object.create(null), idx.files);
+      idx.docs     = Object.assign(Object.create(null), idx.docs);
+      idx.postings = Object.assign(Object.create(null), idx.postings);
       return idx as Index;
     }
   } catch { /* missing / corrupt / wrong schema — caller rebuilds */ }

--- a/test/main/features/search/index.test.ts
+++ b/test/main/features/search/index.test.ts
@@ -548,6 +548,59 @@ describe('search › searchContexts', () => {
 });
 
 describe('search › searchChats — group-chat shape end-to-end', () => {
+  it.each(['constructor', '__proto__'])(
+    'indexes and searches a new message containing %s after restarting with a saved index',
+    async (term) => {
+      const messages = [{ from: 'user', text: 'baseline message', ts: 't1' }];
+      writeChat(TEST_UID, 'restart-chat', messages);
+      const oldIndexer = await import('../../../../src/main/features/search/indexer');
+      await oldIndexer.reconcileChatsIndex(TEST_UID);
+      await oldIndexer.flushAll();
+      vi.resetModules();
+
+      const message = { from: 'user', text: `${term} freshmarker`, ts: 't2' };
+      writeChat(TEST_UID, 'restart-chat', [...messages, message]);
+      const ix = await import('../../../../src/main/features/search/indexer');
+      await ix.indexChatMessage(TEST_UID, 'restart-chat', 1, message);
+      const s = await loadSearch();
+      expect(await s.searchChats(TEST_UID, 'freshmarker')).toMatchObject([
+        { cid: 'restart-chat', msg_index: 1, snippet: message.text },
+      ]);
+      expect(await s.searchChats(TEST_UID, term)).toHaveLength(1);
+      expect(await s.searchChats(TEST_UID, term === 'constructor' ? '__proto__' : 'constructor')).toEqual([]);
+      await ix.dropChatConversation(TEST_UID, 'restart-chat');
+      // Remove the source too so reconciliation cannot re-add it.
+      fs.unlinkSync(path.join(tmpDir, TEST_UID, 'cloud', 'chats', 'restart-chat.jsonl'));
+      expect(await s.searchChats(TEST_UID, term)).toEqual([]);
+    },
+  );
+
+  it('rebuilds a v4 index with incomplete postings even when source metadata is unchanged', async () => {
+    const message = { from: 'user', text: 'constructor recoveredmarker', ts: 't1' };
+    writeChat(TEST_UID, 'partial-chat', [message]);
+    const paths = await import('../../../../src/main/paths');
+    const idxPath = paths.userChatsIndexPath(TEST_UID);
+    const source = path.join(tmpDir, TEST_UID, 'cloud', 'chats', 'partial-chat.jsonl');
+    const stat = fs.statSync(source);
+    fs.mkdirSync(path.dirname(idxPath), { recursive: true });
+    // A failed append can leave the doc present without its posting rows;
+    // later successful appends can make the file metadata look up to date.
+    fs.writeFileSync(idxPath, JSON.stringify({
+      version: 4, kind: 'chat',
+      files: { 'partial-chat': { mtime: stat.mtimeMs, size: stat.size } },
+      docs: { 'chat:partial-chat:0': {
+        kind: 'chat', fileKey: 'partial-chat', cid: 'partial-chat', msg_index: 0,
+        len: message.text.length, _tokens: ['constructor', 'recoveredmarker'],
+      } },
+      postings: {},
+    }));
+    const s = await loadSearch();
+    expect(await s.searchChats(TEST_UID, 'recoveredmarker')).toMatchObject([
+      { cid: 'partial-chat', msg_index: 0, snippet: message.text },
+    ]);
+    expect(fs.readFileSync(source, 'utf8')).toBe(JSON.stringify(message) + '\n');
+  });
+
   it('finds a query token in current group-chat jsonl shape and returns a snippet', async () => {
     // Pin the bug-fix path: bus refactor changed `<cid>.jsonl` from
     // `{role, content, time}` to `{id, ts, from, to, mentions, text}`.

--- a/test/main/features/search/storage.test.ts
+++ b/test/main/features/search/storage.test.ts
@@ -86,6 +86,26 @@ describe('search/storage › loadIndex', () => {
 });
 
 describe('search/storage › saveIndex', () => {
+  it.each(['chat', 'context'] as const)('preserves dictionary keys and missing-key semantics after reloading %s', async (kind) => {
+    const p = path.join(tmpDir, 'dictionary.json');
+    const idx = emptyIndex(kind);
+    idx.files.__proto__ = { mtime: 42, size: 12 };
+    idx.docs.constructor = { kind, fileKey: '__proto__', len: 12 };
+    idx.postings.__proto__ = [['constructor', 1]];
+    await saveIndex(p, idx);
+    const loaded = await loadIndex(p, kind);
+    expect(loaded.files.__proto__).toEqual({ mtime: 42, size: 12 });
+    expect(loaded.docs.constructor).toMatchObject({ fileKey: '__proto__' });
+    expect(loaded.postings.__proto__).toEqual([['constructor', 1]]);
+    // Missing terms must not resolve to Object.prototype functions after JSON IO.
+    expect(loaded.postings.constructor).toBeUndefined();
+    expect(loaded.files.toString).toBeUndefined();
+    expect(loaded.docs.hasOwnProperty).toBeUndefined();
+    loaded.postings.constructor = [['constructor', 2]];
+    await saveIndex(p, loaded);
+    expect((await loadIndex(p, kind)).postings.constructor).toEqual([['constructor', 2]]);
+  });
+
   it('saveIndex + loadIndex roundtrip preserves shape', async () => {
     const p = path.join(tmpDir, 'rt.json');
     const idx: Index = {
@@ -111,7 +131,7 @@ describe('search/storage › saveIndex', () => {
 
   it('saveIndex mkdirs nested parent directories', async () => {
     const p = path.join(tmpDir, 'deep', 'nested', 'idx.json');
-    await saveIndex(p, emptyIndex('skill_chat'));
+    await saveIndex(p, emptyIndex('chat'));
     expect(fs.existsSync(p)).toBe(true);
   });
 });


### PR DESCRIPTION
Fix local searches after restarting with a saved index. JSON loading now preserves dictionary semantics for terms such as `constructor` and `__proto__`, and older incomplete derived indexes rebuild from original messages without changing chat history.

Regression coverage includes restart, incremental indexing, absent special terms, deletion, and recovery of incomplete indexes. All five new cases fail before the fix.

Validation:
- 356 focused tests; full JavaScript suite: 8,663 passed, 15 skipped; resource tests: 415 passed.
- Main and core-agent typechecks, E2E typecheck, 1,020 platform-native tests, smoke, and Linux x64/arm64 CI pass.
- Desktop E2E: 141 passed, 3 failed. All seven Library/search cases pass. Two attachment cases still expect the old 5 MiB text limit and reproduce on unchanged main. The Commander process-label case is intermittent: bounded same-directory controls reproduce the identical failure without this patch, and the final patched tree also passes it. Original failures remain recorded.

Existing Linux GLib/Sharp and dependency-audit diagnostics are unchanged from the preceding validation run. Successful desktop E2E cases do not retain complete Electron runtime logs, so this does not claim a clean runtime-log baseline.
