### PR TITLE
fix(todo): keep tall board columns scrollable

### DIFF
--- a/src/renderer/style.css
+++ b/src/renderer/style.css
@@ -1760,7 +1760,11 @@ body.is-sidebar-resizing iframe { pointer-events: none; }
 .todo-board { display: grid; grid-template-columns: repeat(4, minmax(190px, 1fr)); gap: 0; align-items: stretch; overflow-x: auto; border: 1px solid var(--border); border-radius: var(--radius-md); background: var(--surface); }
 .todo-board[hidden], .todo-column-body[hidden], .todo-load-error[hidden] { display: none; }
 .project-todo-list { overflow: auto; min-height: 0; }
-.todo-column { min-width: 0; border: 0; border-right: 1px solid var(--border); border-radius: 0; background: transparent; overflow: hidden; }
+/* The board is a flex child of the scrolling list, so a column taller than the
+   panel is shrunk to it instead of overflowing, and the list's own scrollbar
+   never appears: 15 to-dos left 1379px of cards clipped and unreachable. Each
+   column scrolls its own body, which also keeps the status header in place. */
+.todo-column { min-width: 0; display: flex; flex-direction: column; min-height: 0; border: 0; border-right: 1px solid var(--border); border-radius: 0; background: transparent; overflow: hidden; }
 .todo-column:last-child { border-right: 0; }
 .todo-column-head { display: flex; align-items: center; min-height: 44px; padding: 0 10px; gap: 4px; }
 .todo-collapse { flex: 1; min-width: 0; display: flex; align-items: center; gap: 8px; color: var(--text-2); font: inherit; font-size: 12px; font-weight: 600; border: 0; background: transparent; padding: 10px 2px; cursor: pointer; text-align: left; }
@@ -1770,7 +1774,10 @@ body.is-sidebar-resizing iframe { pointer-events: none; }
 .todo-column.is-progress > .todo-column-head .project-todo-status-dot { background: var(--primary); }
 .todo-column.is-review > .todo-column-head .project-todo-status-dot { background: var(--warn-text); }
 .todo-column.is-done > .todo-column-head .project-todo-status-dot { background: var(--success); }
-.todo-column-body { display: flex; flex-direction: column; gap: 8px; padding: 10px; border-top: 1px solid var(--border); }
+.todo-column-body { flex: 1 1 auto; min-height: 0; overflow-y: auto; display: flex; flex-direction: column; gap: 8px; padding: 10px; border-top: 1px solid var(--border); }
+/* Cards keep their own height inside the scroller; as flex children they would
+   otherwise be squashed to fit the column instead of scrolling. */
+.todo-column-body > * { flex: 0 0 auto; }
 .todo-column-empty { width: 100%; padding: 12px 0; font-size: 11px; text-align: center; }
 .todo-board .project-todo-item { position: relative; display: flex; flex-wrap: wrap; gap: 8px; padding: 12px; border: 1px solid var(--border); border-radius: var(--radius-sm); background: var(--surface); box-shadow: 0 1px 2px rgba(15, 23, 42, .03); cursor: default; }
 .todo-board .project-todo-item:hover { border-color: var(--border-strong); }

--- a/test/e2e/todos_e2e_board.spec.ts
+++ b/test/e2e/todos_e2e_board.spec.ts
@@ -434,3 +434,76 @@ test('assigns global and project todos in the editor and keeps cards and saved o
     }
   }
 });
+
+// A status column can hold more to-dos than the board is tall. The board is a
+// flex child of the scrolling panel, so such a column is shrunk to the panel
+// instead of overflowing it, and without a scroller of its own it simply clipped
+// the rest of the cards away with no way to reach them. The single card in a
+// column that cannot overflow is the oracle for "kept its own height": a body
+// that fits by squashing its cards would scroll too, and would be just as
+// unusable.
+test('reaches every to-do in a column taller than the board', async ({ connectorOrkas: orkas }, testInfo) => {
+  const page = orkas.page!;
+  await page.setViewportSize({ width: 1440, height: 900 });
+  await page.evaluate(() => (window as any).setLang('zh'));
+  const created = await orkas.invoke<{ project: { project_id: string } }>('projects.create', { name: '滚动验证' });
+  const pid = created.project.project_id;
+  const detail = '一段足够长的说明文字，用来让卡片高度接近真实情况，从而让这一列超出看板高度。';
+  for (let index = 1; index <= 15; index += 1) {
+    await orkas.invoke('projects.tasks.create', { projectId: pid, title: `待办 ${index}`, status: 'todo', detail });
+  }
+  await orkas.invoke('projects.tasks.create', { projectId: pid, title: '对照待办', status: 'progress', detail });
+  const measure = (sel: string, viewSel: string) => page.evaluate(({ sel, viewSel }) => {
+    const column = document.querySelector(`${sel} .todo-column.is-todo`) as HTMLElement;
+    const body = column.querySelector('.todo-column-body') as HTMLElement;
+    const head = column.querySelector('.todo-column-head') as HTMLElement;
+    const cards = Array.from(column.querySelectorAll('.project-todo-item')) as HTMLElement[];
+    const reference = document.querySelector(`${sel} .todo-column.is-progress .project-todo-item`) as HTMLElement;
+    const last = cards[cards.length - 1].getBoundingClientRect();
+    const view = (document.querySelector(viewSel) as HTMLElement).getBoundingClientRect();
+    return {
+      cards: cards.length,
+      cardHeight: Math.round(last.height),
+      referenceHeight: Math.round(reference.getBoundingClientRect().height),
+      hiddenInBody: body.scrollHeight - body.clientHeight,
+      headTop: Math.round(head.getBoundingClientRect().top),
+      lastVisible: last.bottom <= view.bottom + 1 && last.top >= view.top - 1,
+    };
+  }, { sel, viewSel });
+
+  // The global page scrolls as one list, so a column there must not turn into a
+  // second scroller nested inside it.
+  await page.locator('#todos-btn').click();
+  await page.locator('[data-todo-group="status"]').click();
+  await expect(page.locator('#todos-content .todo-column.is-todo .project-todo-item')).toHaveCount(15);
+  const globalBefore = await measure('#todos-content', '#todos-content');
+  expect(globalBefore.hiddenInBody).toBeLessThanOrEqual(2);
+  expect(globalBefore.cardHeight).toBeGreaterThanOrEqual(globalBefore.referenceHeight - 2);
+  await page.evaluate(() => {
+    const list = document.querySelector('#todos-content') as HTMLElement;
+    list.scrollTop = list.scrollHeight;
+  });
+  expect((await measure('#todos-content', '#todos-content')).lastVisible).toBe(true);
+
+  // The project board gives each column its own scroller instead.
+  await page.locator('#todos-content .project-todo-item').first().locator('.todo-card-project').click();
+  await expect(page.locator('#project-detail-title')).toHaveText('滚动验证');
+  await page.locator('[data-project-tab="todo"]').click();
+  const body = page.locator('#project-todo-list .todo-column.is-todo .todo-column-body');
+  await expect(page.locator('#project-todo-list .todo-column.is-todo .project-todo-item')).toHaveCount(15);
+  const before = await measure('#project-todo-list', '#project-todo-list .todo-column.is-todo');
+  expect(before.cards).toBe(15);
+  expect(before.cardHeight).toBeGreaterThanOrEqual(before.referenceHeight - 2);
+  expect(before.hiddenInBody).toBeGreaterThan(100);
+  expect(before.lastVisible).toBe(false);
+  const box = (await body.boundingBox())!;
+  await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
+  await page.mouse.wheel(0, 600);
+  await expect.poll(async () => body.evaluate((element) => element.scrollTop)).toBeGreaterThan(0);
+  await body.evaluate((element) => { element.scrollTop = element.scrollHeight; });
+  const after = await measure('#project-todo-list', '#project-todo-list .todo-column.is-todo');
+  expect(after.lastVisible).toBe(true);
+  expect(after.cardHeight).toBeGreaterThanOrEqual(after.referenceHeight - 2);
+  expect(after.headTop).toBe(before.headTop);
+  await page.screenshot({ path: testInfo.outputPath('todo-column-scroll.png') });
+});


### PR DESCRIPTION
Tall status columns on project boards can clip lower to-do cards, leaving them unreachable. Give each column body vertical scrolling while keeping its header in place and preserving card height. The global to-do page retains its existing page-level scrolling.

Adds a real Electron regression with 15 cards. It fails against the previous CSS and passes with this fix, checking the last card is reachable, the header stays fixed, and cards are not compressed.

Validation: 11,737 JavaScript tests passed (30 skipped), 538 resource tests plus 10 subtests passed, 201 desktop E2E tests passed, and 1,258 native tests passed (26 skipped) plus 5 GUI checks. Main/core and E2E typechecks, smoke, and open-source boundary checks passed. Initial local dependency/Python setup failures were resolved before the final runs; existing development/runtime warnings and one moderate dependency advisory remain.
